### PR TITLE
fix: sync played status to library cache on toggle

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -2740,9 +2740,20 @@ class DetailsPage extends Page {
 
             this._item.UserData = this._item.UserData || {};
             this._item.UserData.Played = !isPlayed;
+
+            this._updateCachedPlayedStatus();
         } catch (error) {
             log.error('Failed to toggle watched', error);
         }
+    }
+
+    _updateCachedPlayedStatus() {
+        const cachedItem = Object.entries(state.getAll())
+            .filter(([key, cached]) => key.startsWith('library:state:') && cached?.stateData?.items)
+            .flatMap(([, cached]) => cached.stateData.items)
+            .find(({ Id }) => Id === this._itemId);
+
+        if (cachedItem) cachedItem.UserData = { ...cachedItem.UserData, ...this._item.UserData };
     }
 
     async _resetProgress() {


### PR DESCRIPTION
## Summary
  When toggling watched/unwatched on the DetailsPage, the LibraryPage grid cache retains stale `UserData`. On back navigation the played badge does not reflect the   updated state.
  This propagates `UserData` to the cached library items so the played indicator is immediately correct without a full re-fetch.
  Closes #12
  ## What changed
  After `_toggleWatched` updates the API and local item state, `_updateCachedPlayedStatus` finds the matching item in the `library:state:*` cache and patches its   `UserData` in place.