### PR TITLE
fix(audio/webos): correct track selection and silent codec switching for DV/DTS content

### DIFF
--- a/src/api/profiles/WebOSProfile.js
+++ b/src/api/profiles/WebOSProfile.js
@@ -478,21 +478,18 @@ export function buildJellyfinProfile(options = {}) {
         });
     }
 
-    // Always include EAC3 (Dolby Digital Plus) in the safe-to-transmux audio list.
-    // TrueHD and DTS can silently block the Dolby Vision decode pipeline on WebOS,
-    // so we deliberately omit them here and let the DirectPlay audio profiles handle
-    // pass-through when the container allows it.
-    let transAudioCodecs = 'aac,ac3,eac3';
+    // WebOS native: omit AAC so Jellyfin is forced to transcode DTS/TrueHD → AC3/EAC3.
+    // Jellyfin ignores list order and internally prefers AAC; removing it entirely is the
+    // only way to guarantee AC3 output, which actually plays in MPEG-TS HLS on WebOS.
+    // HTML5 (Hls.js): keep AAC as primary for browser compatibility.
+    let transAudioCodecs = isHtml5 ? 'aac,ac3,eac3' : 'ac3,eac3';
 
-    // Full set of video codecs for transcoding/remuxing.
-    // We do NOT restrict this to HEVC-only when DV is enabled because that would
-    // force a heavyweight HEVC transcode for every H.264 file. Instead, DOVI
-    // routing is handled at the per-profile level (HEVC excluded from TS, present
-    // in fMP4) so the server's rank-based selection picks the right container.
     let transVideoCodecs = enableHEVC ? 'h264,hevc' : 'h264';
 
     if (playbackMode === 'remux') {
-        transAudioCodecs = 'copy';
+        // Video copy for quality, audio transcoded via transAudioCodecs above.
+        // AllowAudioStreamCopy=false (set in _getPlaybackInfo remux case) ensures
+        // the server transcodes audio even when the source codec is in the list.
         transVideoCodecs = 'copy';
     }
 
@@ -799,6 +796,22 @@ export function buildJellyfinProfile(options = {}) {
         Codec: 'flac',
         Conditions: [{ Condition: 'LessThanEqual', Property: 'AudioChannels', Value: '2', IsRequired: false }]
     });
+
+    // Impossible condition (channels never = 0) blocks stream-copy of disabled codecs, forcing AAC transcode.
+    if (!enableDts) {
+        codecProfiles.push({
+            Type: 'VideoAudio',
+            Codec: 'dts,dca,dtshd',
+            Conditions: [{ Condition: 'Equals', Property: 'AudioChannels', Value: '0', IsRequired: true }]
+        });
+    }
+    if (!enableTrueHd) {
+        codecProfiles.push({
+            Type: 'VideoAudio',
+            Codec: 'truehd',
+            Conditions: [{ Condition: 'Equals', Property: 'AudioChannels', Value: '0', IsRequired: true }]
+        });
+    }
 
     // -------------------------------------------------------------------------
     // Dolby Vision MKV — Force Remux on WebOS < 25

--- a/src/player/core/JellyfinPlayer.js
+++ b/src/player/core/JellyfinPlayer.js
@@ -1115,49 +1115,29 @@ export class JellyfinPlayer extends EventEmitter {
     async setAudioStreamIndex(index) {
         this._currentAudioStreamIndex = index;
 
-        // =====================================================================
-        // Determine whether we need to restart playback to apply the audio change.
-        // =====================================================================
-        // True whenever the audio codec is baked into the server's HLS output and
-        // cannot be switched without a full PlaybackInfo restart + re-profile.
-        //
-        // 'Remux' must be included here: in Remux sessions, audio runs through the
-        // server's HLS transcoding pipeline too (even if video is copied). Falling
-        // through to the native AVPlay setSelectTrack path would bypass the
-        // enableFlacInVideo gate and let FLAC play directly → 2s sync issue.
-        const isTranscoding = this._currentPlayMethod === 'Transcode' ||
-                              this._currentPlayMethod === 'DirectStream' ||
-                              this._currentPlayMethod === 'Remux';
-
-        // Determine if the newly selected track's codec is natively supported
-        // by the current backend. If it isn't (e.g. FLAC on Tizen when disabled),
-        // we MUST force a restart so the server can re-evaluate and transcode.
         let isTargetCodecSupported = true;
-        if (this._backendType === 'tizen') {
+        if (this._backendType === 'tizen' || this._backendType === 'webos') {
             const AudioTracks = this.getAudioTracks();
             const targetTrack = AudioTracks.find(t => t.Index === index);
             if (targetTrack && targetTrack.Codec) {
                 const targetCodec = targetTrack.Codec.toLowerCase();
-                
-                // FLAC video transcode gate
-                if ((targetCodec === 'flac' || targetCodec === 'alac') && !PlayerSettings.get('enableFlacInVideo')) {
+                if (this._backendType === 'tizen' && (targetCodec === 'flac' || targetCodec === 'alac') && !PlayerSettings.get('enableFlacInVideo')) {
                     isTargetCodecSupported = false;
-                }
-                // DTS passthrough gate
-                else if (targetCodec.includes('dts') && !PlayerSettings.get('enableDts')) {
+                } else if (targetCodec.includes('dts') && !PlayerSettings.get('enableDts')) {
                     isTargetCodecSupported = false;
-                }
-                // TrueHD passthrough gate
-                else if (targetCodec === 'truehd' && !PlayerSettings.get('enableTrueHd')) {
+                } else if (targetCodec === 'truehd' && !PlayerSettings.get('enableTrueHd')) {
                     isTargetCodecSupported = false;
                 }
             }
         }
 
-        // True whenever this backend cannot live-switch audio tracks.
-        // WebOS reports true for supportsNativeAudioTracks, so it is treated
-        // like Tizen for DirectPlay: no restart needed for audio switching.
         const supportsNativeAudio = this._backend && typeof this._backend.supportsNativeAudioTracks === 'function' && this._backend.supportsNativeAudioTracks();
+
+        // Remux on WebOS with a supported codec: HLS already has all tracks, switch natively.
+        // Remux on Tizen always restarts — AVPlay FLAC gate must stay in effect.
+        const isTranscoding = this._currentPlayMethod === 'Transcode' ||
+                              this._currentPlayMethod === 'DirectStream' ||
+                              (this._currentPlayMethod === 'Remux' && !(this._backendType === 'webos' && isTargetCodecSupported && supportsNativeAudio));
         const requiresRestart = isTranscoding || !isTargetCodecSupported || (this._backendType !== 'tizen' && !supportsNativeAudio);
 
         log.info(`setAudioStreamIndex: index=${index} playMethod=${this._currentPlayMethod} requiresRestart=${requiresRestart} isTargetCodecSupported=${isTargetCodecSupported}`);
@@ -1178,15 +1158,15 @@ export class JellyfinPlayer extends EventEmitter {
                 }
             }
 
-            // Build new play options carrying the updated audio stream index.
+            // 'auto' preserves CodecProfiles so Jellyfin transcodes unsupported codecs correctly.
+            const restartPlaybackMode = this._playbackMode === 'transcode' ? 'transcode'
+                : !isTargetCodecSupported ? 'auto'
+                : 'remux';
             const restartOptions = {
                 ...this._currentPlayOptions,
                 audioStreamIndex: index,
                 startPositionTicks: currentTicks,
-                // Ensure we use remux mode (at minimum) for track selection on HTML5, 
-                // but preserve transcode mode if it was explicitly selected.
-                playbackMode: this._playbackMode === 'transcode' ? 'transcode' : 'remux',
-                // Only force DirectStream if backend can't switch natively AND the track isn't the default direct play track
+                playbackMode: restartPlaybackMode,
                 _forceDirectStream: this._backendType !== 'tizen' && !supportsNativeAudio && isCustomAudioTrack
             };
 

--- a/src/player/core/WebOSPlayer.js
+++ b/src/player/core/WebOSPlayer.js
@@ -466,14 +466,19 @@ export class WebOSPlayer {
             const listIndex = audioStreams.findIndex(s => s.Index === options.audioStreamIndex);
             const resolvedIndex = listIndex >= 0 ? listIndex : 0;
 
+            // In Transcode/DirectStream mode the server outputs only the selected audio
+            // track at HLS output position 0. The file-level list index (resolvedIndex)
+            // refers to the source file and doesn't apply to the single-track HLS output.
+            const outputIndex = (options.playMethod && options.playMethod !== 'DirectPlay') ? 0 : resolvedIndex;
+
             if (hls) {
-                if (resolvedIndex < hls.audioTracks.length) {
-                    hls.audioTrack = resolvedIndex;
-                    log.debug('WebOSPlayer: Hls.js audio track set to', resolvedIndex);
+                if (outputIndex < hls.audioTracks.length) {
+                    hls.audioTrack = outputIndex;
+                    log.debug('WebOSPlayer: Hls.js audio track set to', outputIndex);
                 }
             } else {
                 // Native: toggle HTML5 AudioTrack objects
-                this.setAudioStreamIndex(resolvedIndex);
+                this.setAudioStreamIndex(outputIndex);
             }
         }
 
@@ -771,6 +776,14 @@ export class WebOSPlayer {
             audioTracks[i].enabled = (i === listIndex);
         }
         log.info('WebOSPlayer: Native audio track → list index', listIndex);
+
+        // WebOS native media pipeline does not apply audioTracks.enabled changes
+        // mid-playback without a seek. A sub-frame back-seek (≤0.1 s) forces the
+        // hardware decoder to reinitialize with the new track state while staying
+        // in DirectPlay mode (preserving Dolby Vision passthrough).
+        if (video.readyState >= 2 /* HAVE_CURRENT_DATA */ && video.currentTime > 0.1) {
+            video.currentTime = video.currentTime - 0.1;
+        }
     }
 
     /**

--- a/src/player/core/WebOSPlayer.js
+++ b/src/player/core/WebOSPlayer.js
@@ -346,23 +346,18 @@ export class WebOSPlayer {
         // MIME types like 'video/x-matroska' causes the Chromium layer to
         // silently reject the source before the media pipeline sees it.
         video.src = options.url;
-        video.autoplay = true;
 
         video.load();
 
         return new Promise((resolve, reject) => {
-            const onLoadedMetadata = () => {
-                video.removeEventListener('loadedmetadata', onLoadedMetadata);
-                this._applyInitialTracks(options);
-            };
-
             const onCanPlay = () => {
                 video.removeEventListener('canplay', onCanPlay);
                 video.removeEventListener('error', onError);
 
-                if (options.playerStartPositionTicks) {
-                    // Pre-seek logic disabled here; robust resume will handle it
-                }
+                // Apply audio/subtitle tracks at canplay — same timing as _playNativeHls.
+                // audioTracks is not reliably populated at loadedmetadata on WebOS native
+                // player, so doing it here (before play()) ensures the array is ready.
+                this._applyInitialTracks(options);
 
                 video.play()
                     .then(() => {
@@ -374,11 +369,9 @@ export class WebOSPlayer {
 
             const onError = () => {
                 video.removeEventListener('canplay', onCanPlay);
-                video.removeEventListener('loadedmetadata', onLoadedMetadata);
                 reject(video.error || new Error('Direct playback load failed'));
             };
 
-            video.addEventListener('loadedmetadata', onLoadedMetadata);
             video.addEventListener('canplay', onCanPlay);
             video.addEventListener('error', onError);
         });
@@ -466,18 +459,16 @@ export class WebOSPlayer {
             const listIndex = audioStreams.findIndex(s => s.Index === options.audioStreamIndex);
             const resolvedIndex = listIndex >= 0 ? listIndex : 0;
 
-            // In Transcode/DirectStream mode the server outputs only the selected audio
-            // track at HLS output position 0. The file-level list index (resolvedIndex)
-            // refers to the source file and doesn't apply to the single-track HLS output.
-            const outputIndex = (options.playMethod && options.playMethod !== 'DirectPlay') ? 0 : resolvedIndex;
-
             if (hls) {
+                // Single-track = Transcode/DirectStream (server picked one); multi-track = Remux/DirectPlay.
+                const outputIndex = hls.audioTracks.length <= 1 ? 0 : resolvedIndex;
                 if (outputIndex < hls.audioTracks.length) {
                     hls.audioTrack = outputIndex;
                     log.debug('WebOSPlayer: Hls.js audio track set to', outputIndex);
                 }
             } else {
-                // Native: toggle HTML5 AudioTrack objects
+                const nativeTracks = this._videoElement?.audioTracks;
+                const outputIndex = (!nativeTracks || nativeTracks.length <= 1) ? 0 : resolvedIndex;
                 this.setAudioStreamIndex(outputIndex);
             }
         }


### PR DESCRIPTION
Closes #82

## Problem

On WebOS with Dolby Vision enabled and LG Native player, MKV files with multiple audio tracks (HEVC DV + EAC3 + DTS) had three issues:

**Default track silent on start.** `_applyInitialTracks` always used `outputIndex = 0` for non-DirectPlay modes. In Remux mode (forced by the DV-in-MKV CodecProfile), the HLS preserves all source tracks, so index 0 always picked the first file track regardless of what Jellyfin set as default.

**Switching to another track produced silence.** The audio switch restarted with `playbackMode: 'remux'`, which sets `AllowAudioStreamCopy = true` and clears `CodecProfiles = []`. This removed the DTS/TrueHD blocking conditions, so Jellyfin stream-copied the unsupported codec directly into HLS. The TV hardware could not decode it without passthrough.

**Unnecessary video reload when switching supported tracks.** All Remux audio switches triggered a full stop/restart, even between two EAC3 tracks already in the HLS manifest.

## Changes

**`WebOSProfile.js`**
- Added impossible-condition `VideoAudio` CodecProfiles for `dts,dca,dtshd` and `truehd` when their passthrough settings are off, forcing Jellyfin to transcode to AC3/EAC3 instead of stream-copying.
- Split `transAudioCodecs` by backend: native uses `ac3,eac3`, HTML5 uses `aac,ac3,eac3`. Jellyfin internally prefers AAC; removing it from the native list guarantees AC3 output.

**`WebOSPlayer.js`**
- `_applyInitialTracks` now checks actual `audioTracks.length` at canplay time. Single track (Transcode/DirectStream) uses index 0. Multiple tracks (Remux) use `resolvedIndex` matching the requested stream.

**`JellyfinPlayer.js`**
- Extended `isTargetCodecSupported` to the `webos` backend for DTS and TrueHD passthrough gates.
- Carved Remux out of `isTranscoding` for WebOS when the codec is supported and native audio switching is available. Supported track switches now use the native `audioTracks` API with a micro-seek instead of a full reload.
- When restarting for an unsupported codec, use `playbackMode: 'auto'` instead of `'remux'` so CodecProfiles are preserved and the DTS/TrueHD block stays active.

## Result

| Scenario | Before | After |
|---|---|---|
| DV MKV, default EAC3 track | Silent | Plays |
| Switch EAC3 to EAC3 (Remux) | Full video reload | Native switch, no reload |
| Switch EAC3 to DTS (passthrough off) | Silent | Restart, transcoded to AC3 |
| Switch EAC3 to DTS (passthrough on) | Silent (wrong index) | Native switch, DTS passthrough |