### PR TITLE
fix: correct track selection

### DIFF
--- a/src/player/core/JellyfinPlayer.js
+++ b/src/player/core/JellyfinPlayer.js
@@ -1074,6 +1074,7 @@ export class JellyfinPlayer extends EventEmitter {
                 mediaSource,
                 startPositionTicks: streamInfo.playerStartPositionTicks, // Use adjusted start position
                 audioStreamIndex: this._currentAudioStreamIndex,
+                audioTrackListIndex: this._getBackendAudioTrackListIndex(this._currentAudioStreamIndex, mediaSource),
                 subtitleStreamIndex: options.subtitleStreamIndex,
                 // Tell the backend what play method was negotiated — critical so
                 // TizenAVPlayer knows NOT to apply native track selection when

--- a/src/player/core/JellyfinPlayer.js
+++ b/src/player/core/JellyfinPlayer.js
@@ -1389,8 +1389,8 @@ export class JellyfinPlayer extends EventEmitter {
         // Both Tizen (AVPlay) and HtmlVideoPlayer work with 0-based list
         // indices of available audio tracks, NOT the raw Jellyfin stream ID.
         // Convert here so both backends share the same simple interface.
-        const tracks = this.getAudioTracks();
-        const listIndex = tracks.findIndex((t) => t.Index === index);
+        const tracks = this._getBackendAudioTracks();
+        const listIndex = this._getBackendAudioTrackListIndex(index);
 
         if (listIndex === -1) {
             log.warn('StreamID', index, 'not found in audio tracks:', tracks.map(t => t.Index));
@@ -1856,6 +1856,54 @@ export class JellyfinPlayer extends EventEmitter {
      */
     getAudioTracks() {
         return this._currentMediaSource?.MediaStreams?.filter((s) => s.Type === 'Audio') || [];
+    }
+
+    /**
+     * Get audio tracks as exposed by the current native backend.
+     *
+     * Jellyfin keeps original stream IDs, including tracks the WebOS native
+     * audioTracks API will not expose when passthrough codecs are disabled.
+     * Counting those hidden tracks shifts the backend list index by one.
+     *
+     * @param {Object} [mediaSource]
+     * @returns {Array} Backend-visible audio streams
+     * @private
+     */
+    _getBackendAudioTracks(mediaSource = this._currentMediaSource) {
+        const tracks = mediaSource?.MediaStreams?.filter((s) => s.Type === 'Audio') || [];
+
+        if (this._backendType !== 'webos') {
+            return tracks;
+        }
+
+        return tracks.filter((track) => {
+            const codec = (track.Codec || '').toLowerCase();
+
+            if (codec === 'truehd' && !PlayerSettings.get('enableTrueHd')) {
+                return false;
+            }
+
+            if ((codec.includes('dts') || codec === 'dca') && !PlayerSettings.get('enableDts')) {
+                return false;
+            }
+
+            return true;
+        });
+    }
+
+    /**
+     * Convert a Jellyfin audio stream Index to the 0-based backend track index.
+     * @param {number} streamIndex
+     * @param {Object} [mediaSource]
+     * @returns {number}
+     * @private
+     */
+    _getBackendAudioTrackListIndex(streamIndex, mediaSource = this._currentMediaSource) {
+        if (streamIndex === undefined || streamIndex === null) {
+            return -1;
+        }
+
+        return this._getBackendAudioTracks(mediaSource).findIndex((t) => t.Index === streamIndex);
     }
 
     /**

--- a/src/player/core/WebOSPlayer.js
+++ b/src/player/core/WebOSPlayer.js
@@ -484,11 +484,9 @@ export class WebOSPlayer {
     _applyInitialTracks(options, hls) {
         // ---- Audio track ----
         if (options.audioStreamIndex !== undefined && options.audioStreamIndex !== null) {
-            // Convert Jellyfin stream index (e.g. 1) to 0-based audio-only list index (e.g. 0)
-            // so it maps correctly onto hls.audioTracks / video.audioTracks arrays.
-            const audioStreams = (options.mediaSource?.MediaStreams || []).filter(s => s.Type === 'Audio');
-            const listIndex = audioStreams.findIndex(s => s.Index === options.audioStreamIndex);
-            const resolvedIndex = listIndex >= 0 ? listIndex : 0;
+            // JellyfinPlayer precomputes the backend-visible list index because
+            // WebOS may hide unsupported passthrough tracks from audioTracks.
+            const resolvedIndex = options.audioTrackListIndex >= 0 ? options.audioTrackListIndex : 0;
 
             if (hls) {
                 // Single-track = Transcode/DirectStream (server picked one); multi-track = Remux/DirectPlay.


### PR DESCRIPTION
## Description

Fixes audio track selection on webOS when Jellyfin exposes audio streams that the LG native player does not expose through `video.audioTracks`.

For example, with a source containing `ENG TrueHD`, `ENG AC3`, and `FR AC3`, webOS may hide the unsupported TrueHD track while Litefin still uses Jellyfin's original stream `Index` values. The previous conversion from Jellyfin `AudioStreamIndex` to native `audioTracks[n]` counted the hidden stream, so selecting the AC3 compatibility track could enable the wrong native audio track and result in no audio.

This change adds a separate backend audio track list index computed from the tracks that are actually expected to be visible/selectable on webOS. The original Jellyfin `AudioStreamIndex` is still preserved for server requests, playback restarts, remux/transcode decisions, and OSD state.

Fixes #186 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

- **Platform**: webOS 25
- **Device Model**: OLED55C54LA.DEUQJLP
- **Build Variant Tested**: Build command covers configured variants

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added appropriate JSDoc comments

## Screenshots (if applicable)

Not applicable. This PR does not change the UI.