### PR TITLE
feat(remote): play focused card with the remote Play key on Home

### DIFF
--- a/src/core/App.js
+++ b/src/core/App.js
@@ -510,7 +510,8 @@ class App {
                 audioStreamIndex,
                 subtitleStreamIndex,
                 backdropUrl,
-                fromSlideshow
+                fromSlideshow,
+                fromBrowse
             }) => {
                 log.info('Playback requested for item:', item?.Name, 'ID:', item?.Id);
 
@@ -589,9 +590,15 @@ class App {
                     log.debug(`Setting initial subtitle stream index: ${subtitleStreamIndex}`);
                 }
 
-                // Navigate to player page with item ID and resume flag
+                // Navigate to player page with item ID and resume flag.
+                // fromSlideshow and fromBrowse (the Home/Library Play key) both
+                // mark launchers that should PUSH the player, so Back/Stop returns
+                // to the originating page (see replace flag below).
                 const resumeParam = resume ? 'true' : 'false';
-                const slideshowParam = fromSlideshow ? '?fromSlideshow=true' : '';
+                const queryParts = [];
+                if (fromSlideshow) queryParts.push('fromSlideshow=true');
+                if (fromBrowse) queryParts.push('fromBrowse=true');
+                const queryParam = queryParts.length > 0 ? `?${queryParts.join('&')}` : '';
 
                 // SyncPlay Override: if we are in a SyncPlay group, we do NOT launch the player locally.
                 // Instead, we command the server to start playback of the new item. The server
@@ -614,10 +621,11 @@ class App {
                     return;
                 }
 
-                // If we came from a slideshow, we PUSH the player so we can go BACK to the slideshow.
-                // For all other cases (Details/Library), we REPLACE the previous page to prevent history bloat.
-                router.navigate(`/player/${itemToPlay.Id}/${resumeParam}${slideshowParam}`, {
-                    replace: !fromSlideshow
+                // If we came from a slideshow or a browse-page Play key, we PUSH the
+                // player so we can go BACK to the originating page exactly where we
+                // left off. For DetailsPage launches we REPLACE to prevent history bloat.
+                router.navigate(`/player/${itemToPlay.Id}/${resumeParam}${queryParam}`, {
+                    replace: !fromSlideshow && !fromBrowse
                 });
             }
         );

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -43,6 +43,7 @@ import { i18n } from '../utils/i18n.js';
 import { imageCache } from '../utils/ImageCache.js';
 import { imageService } from '../utils/ImageService.js';
 import CardRenderer from '../utils/CardRenderer.js';
+import { quickPlayItem } from '../utils/QuickPlay.js';
 import { homeLayoutManager } from '../utils/HomeLayoutManager.js';
 import { pluginManager } from '../plugins/PluginManager.js';
 import HeroCarousel from '../ui/HeroCarousel.js';
@@ -1320,6 +1321,44 @@ class HomePage extends Page {
                 rowEntry.virtualRow.syncIndexFromNode(e.target);
             }
         });
+
+        // ── Remote Play key → play the focused card directly ─────────────────
+        // Mirrors the official Jellyfin app: pressing the dedicated Play (or
+        // Play/Pause) key on a focused show/episode card starts playback without
+        // first opening its details page. Both events are bound because remotes
+        // expose either a discrete Play key (key:play) or a combined toggle
+        // (key:playPause). Page._subscriptions auto-unbinds these on destroy.
+        this.on('key:play', () => this._playFocusedCard());
+        this.on('key:playPause', () => this._playFocusedCard());
+    }
+
+    /**
+     * Launch playback of the currently focused media card (remote Play key).
+     * Skips cards that aren't directly playable (library folders, people).
+     */
+    _playFocusedCard() {
+        const card = this.$('.media-card.focused');
+        if (!card?.dataset?.itemId) {
+            log.debug('Play key pressed but no focused media card');
+            return;
+        }
+
+        const { itemId, type, contextType } = card.dataset;
+
+        // Library/collection cards open a library view; people open a person
+        // page — neither is directly playable, so let the Play key fall through.
+        if (contextType === 'library') return;
+        if (['Person', 'MusicArtist', 'Artist', 'AlbumArtist'].includes(type)) return;
+
+        // Persist focus for back-nav restoration, mirroring handleActivate().
+        const sectionEl = card.closest('section[data-row-id]');
+        state.set('home:lastFocusedItem', {
+            itemId,
+            rowId: sectionEl ? sectionEl.getAttribute('data-row-id') : null
+        });
+
+        log.info(`Play key: quick-playing focused card ${itemId} (${type || 'unknown'})`);
+        quickPlayItem(itemId);
     }
 
     // =========================================================================

--- a/src/pages/PlayerPage.js
+++ b/src/pages/PlayerPage.js
@@ -2621,11 +2621,12 @@ class PlayerPage extends Page {
         ) {
             const detailsPath = `/details/${this._item.Id}`;
 
-            // The PlayerPage always replaces the page that launched it in history (to prevent bloat).
-            // HOWEVER: if we came from a slideshow, we want to go BACK to the slideshow exactly
-            // where we left off. In that case, App.js pushed the player instead of replacing,
-            // so we just call router.back().
-            if (this.params.fromSlideshow === 'true') {
+            // The PlayerPage normally replaces the page that launched it in history (to prevent bloat)
+            // and returns to the item's Details page on stop.
+            // HOWEVER: if we came from a slideshow or a browse-page Play key, the player was PUSHED
+            // (not replaced) by App.js, and we want to go BACK to that originating page exactly where
+            // we left off — not synthesize a Details page the user never visited. So we call router.back().
+            if (this.params.fromSlideshow === 'true' || this.params.fromBrowse === 'true') {
                 router.back();
             } else {
                 router.navigate(detailsPath, { replace: true, isBack: true });

--- a/src/utils/QuickPlay.js
+++ b/src/utils/QuickPlay.js
@@ -1,0 +1,186 @@
+/**
+ * ============================================================================
+ * Litefin - Quick Play
+ * ============================================================================
+ * Resolves an arbitrary library item (by id) into a directly playable item and
+ * launches playback. This is the behaviour bound to the remote's dedicated
+ * Play / Play-Pause key when a media card is focused on a browse page (Home,
+ * Library, Favorites, Search, …).
+ *
+ * It mirrors the resolution logic of DetailsPage._play() so that pressing Play
+ * on a Series/Season card behaves like the official Jellyfin app: it jumps
+ * straight to the "Next Up" / first-unwatched episode instead of merely opening
+ * the details page. The actual launch is delegated to the global `player:play`
+ * EventBus handler in App.js (which owns navigation, SyncPlay, and audio-
+ * container resolution), so this module only needs to resolve the *video*
+ * container types it can't handle.
+ * ============================================================================
+ */
+
+import { api } from '../api/index.js';
+import { eventBus } from '../core/EventBus.js';
+import { logger } from './Logger.js';
+
+const log = logger.create('QuickPlay');
+
+/* Types that are never directly playable from a browse card — ignore the key. */
+const NON_PLAYABLE = ['Person', 'CollectionFolder', 'UserView', 'Folder', 'Genre', 'Studio', 'Year'];
+
+/**
+ * Resolve an item id (or partial item) to a playable item and launch it.
+ * @param {string|Object} itemOrId - Item id, or an object with an `Id` field.
+ * @returns {Promise<boolean>} True if a playback request was emitted.
+ */
+export async function quickPlayItem(itemOrId) {
+    if (!itemOrId) return false;
+
+    const id = typeof itemOrId === 'string' ? itemOrId : itemOrId.Id;
+    if (!id) return false;
+
+    // Fetch the full item so we get a reliable Type + UserData (resume position)
+    // and the metadata needed to resolve container types below.
+    let item;
+    try {
+        item = await api.getItem(id);
+    } catch (e) {
+        log.error('Failed to fetch item for quick play:', id, e?.message || e);
+        return false;
+    }
+    if (!item || !item.Type) {
+        log.warn('Quick play aborted — item not found or has no type:', id);
+        return false;
+    }
+
+    if (NON_PLAYABLE.includes(item.Type)) {
+        log.debug(`"${item.Type}" is not directly playable — ignoring Play key`);
+        return false;
+    }
+
+    let itemToPlay = item;
+    let resume = hasResumePosition(item);
+
+    try {
+        if (item.Type === 'Series') {
+            const resolved = await resolveSeries(item);
+            if (!resolved) return false;
+            ({ item: itemToPlay, resume } = resolved);
+        } else if (item.Type === 'Season') {
+            const resolved = await resolveSeason(item);
+            if (!resolved) return false;
+            ({ item: itemToPlay, resume } = resolved);
+        } else if (item.Type === 'BoxSet') {
+            const resolved = await resolveBoxSet(item);
+            if (!resolved) return false;
+            itemToPlay = resolved;
+            resume = hasResumePosition(resolved);
+        } else if (item.Type === 'Program' && item.ChannelId) {
+            // Live TV Program → play the parent Channel (mirrors DetailsPage._play).
+            itemToPlay = { Id: item.ChannelId, Type: 'TvChannel', Name: item.ChannelName || item.Name };
+            resume = false;
+        }
+        // Direct-playable video/audio types fall through unchanged. Audio
+        // containers (MusicAlbum, Playlist, …) also fall through — the global
+        // player:play handler in App.js resolves those to their first track.
+    } catch (e) {
+        log.error(`Failed to resolve a playable item for ${item.Type}:`, e?.message || e);
+        return false;
+    }
+
+    if (!itemToPlay?.Id) {
+        log.warn('Quick play aborted — no resolved item id');
+        return false;
+    }
+
+    log.info(`Quick play: launching "${itemToPlay.Name}" (${itemToPlay.Type}, resume=${resume})`);
+    // fromBrowse tells App.js to PUSH the player (not replace the browse page) so
+    // that stopping playback returns to the page we launched from — not a Details
+    // page the user never opened.
+    eventBus.emit('player:play', { item: itemToPlay, resume, fromBrowse: true });
+    return true;
+}
+
+/** True when an item has saved playback progress to resume from. */
+function hasResumePosition(item) {
+    return (item?.UserData?.PlaybackPositionTicks || 0) > 0;
+}
+
+/**
+ * Series → "Next Up" episode (resume if it has progress), else first episode.
+ */
+async function resolveSeries(series) {
+    const nextUp = await api.getNextUp({ SeriesId: series.Id, Limit: 1 });
+    if (nextUp?.Items?.length > 0) {
+        const ep = nextUp.Items[0];
+        return { item: ep, resume: hasResumePosition(ep) };
+    }
+
+    // Fallback: first episode ever (e.g. S1E1).
+    const firstEp = await api.getItems({
+        ParentId: series.Id,
+        Recursive: true,
+        IncludeItemTypes: 'Episode',
+        Limit: 1,
+        SortBy: 'SortName'
+    });
+    if (firstEp?.Items?.length > 0) {
+        const ep = firstEp.Items[0];
+        return { item: ep, resume: hasResumePosition(ep) };
+    }
+
+    log.warn('No episodes found for series:', series.Id);
+    return null;
+}
+
+/**
+ * Season → first unwatched episode (else first episode). Tagged with the season
+ * context so PlayQueue sequences the rest of the season for auto-advance.
+ */
+async function resolveSeason(season) {
+    const result = await api.getItems({
+        ParentId: season.Id,
+        Recursive: true,
+        IncludeItemTypes: 'Episode',
+        SortBy: 'SortName',
+        Fields: 'UserData'
+    });
+    const episodes = result?.Items || [];
+    if (episodes.length === 0) {
+        log.warn('No episodes found for season:', season.Id);
+        return null;
+    }
+
+    const target = { ...(episodes.find((ep) => !ep.UserData?.Played) || episodes[0]) };
+    target.contextType = 'season';
+    target.contextId = season.Id;
+    return { item: target, resume: hasResumePosition(target) };
+}
+
+/**
+ * BoxSet → first child (Movie preferred, then Episode, then Audio), tagged with
+ * the boxset context + sort order so PlayQueue builds the full ordered queue.
+ */
+async function resolveBoxSet(boxset) {
+    let sortBy = 'PremiereDate';
+    if (boxset.DisplayOrder === 'SortName') sortBy = 'SortName';
+    else if (boxset.DisplayOrder === 'Default') sortBy = 'DateModified';
+
+    const params = { Recursive: true, Limit: 1, SortBy: sortBy, SortOrder: 'Ascending', ParentId: boxset.Id };
+    const [movies, episodes, audio] = await Promise.all([
+        api.getItems({ ...params, IncludeItemTypes: 'Movie' }),
+        api.getItems({ ...params, IncludeItemTypes: 'Episode' }),
+        api.getItems({ ...params, IncludeItemTypes: 'Audio' })
+    ]);
+
+    const target = movies?.Items?.[0] || episodes?.Items?.[0] || audio?.Items?.[0];
+    if (!target) {
+        log.warn('BoxSet is empty, nothing to play:', boxset.Id);
+        return null;
+    }
+
+    target.contextType = 'boxset';
+    target.contextId = boxset.Id;
+    target.boxsetSortBy = sortBy;
+    return target;
+}
+
+export default quickPlayItem;


### PR DESCRIPTION
## Description
Hello, i recently started using Litefin (and really liked it), i switched from the official jellyfin on a samsung tv (Tizen).
i was really used to direcly playing show directly from the home page with the remote play button, so i tried adding this feature.

Pressing the remote's Play / Play-Pause key while a media card is focused on the Home page now starts playback directly, matching the official Jellyfin appg.

- Add QuickPlay util that resolves any browse item to a playable one (Series -> Next Up / first episode, Season -> first unwatched, BoxSet -> first child, Live TV Program -> parent channel) and launches it, resuming when there is saved progress.
- HomePage subscribes to key:play / key:playPause and plays the focused .media-card, skipping non-playable cards (library folders, people).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

- **Platform**: Tizen 4.0
- **Device Model**: UE43NU7025
- **Build Variant Tested**: Legacy

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added appropriate JSDoc comments

## Screenshots (if applicable)

If this PR changes the UI, please provide screenshots.
