### PR TITLE
Update audio transcode profiles

### DIFF
--- a/src/api/profiles/TizenProfile.js
+++ b/src/api/profiles/TizenProfile.js
@@ -448,19 +448,28 @@ export function buildJellyfinProfile(options = {}) {
         // Tizen 6+: AC3/EAC3 in HLS/TS is reliable — use surround sound if preferred.
         if (preferredTranscodeCodec === 'auto') {
             // Auto (Prefer E-AC3) -> default to eac3 first, fallback to ac3.
-            transAudioCodecsArr.push('eac3', 'ac3');
+            if (caps.eac3) transAudioCodecsArr.push('eac3');
+            if (caps.ac3) transAudioCodecsArr.push('ac3');
+            transAudioCodecsArr.push('aac');
         } else if (preferredTranscodeCodec === 'prefer_ac3') {
             // Prefer AC3 (Dolby Digital) -> ac3 first, fallback to eac3.
-            transAudioCodecsArr.push('ac3', 'eac3');
+            if (caps.ac3) transAudioCodecsArr.push('ac3');
+            if (caps.eac3) transAudioCodecsArr.push('eac3');
+            transAudioCodecsArr.push('aac');
         } else if (preferredTranscodeCodec === 'prefer_aac') {
             // Prefer AAC -> use aac.
             transAudioCodecsArr.push('aac');
+            if (caps.eac3) transAudioCodecsArr.push('eac3');
+            if (caps.ac3) transAudioCodecsArr.push('ac3');
         } else if (preferredTranscodeCodec === 'force_eac3') {
             // Force E-AC3 -> only eac3.
             transAudioCodecsArr.push('eac3');
         } else if (preferredTranscodeCodec === 'force_ac3') {
             // Force AC3 -> only ac3.
             transAudioCodecsArr.push('ac3');
+        } else if (preferredTranscodeCodec === 'force_mp3') {
+            // Force MP3 -> only mp3.
+            transAudioCodecsArr.push('mp3');    
         } else {
             // Force AAC -> only aac.
             transAudioCodecsArr.push('aac');
@@ -476,8 +485,6 @@ export function buildJellyfinProfile(options = {}) {
 
     if (enableDts) transAudioCodecsArr.push('dts', 'dca');
     if (enableTrueHd) transAudioCodecsArr.push('truehd');
-
-    let transAudioCodecs = transAudioCodecsArr.join(',');
 
     const directAudioCodecsArr = [];
     if (caps.eac3) directAudioCodecsArr.push('eac3');
@@ -561,8 +568,11 @@ export function buildJellyfinProfile(options = {}) {
         directVideoCodecs = transVideoCodecs;
     }
 
-    const transcodingProfiles = [
-        {
+    const transcodingProfiles = [];
+
+    // 1. Primary HLS video transcoding profile (one for each codec in transAudioCodecsArr)
+    for (const audioCodec of transAudioCodecsArr) {
+        transcodingProfiles.push({
             /*
              * Primary HLS video transcoding profile.
              *
@@ -576,7 +586,7 @@ export function buildJellyfinProfile(options = {}) {
              */
             Container: primaryHlsContainer,
             Type: 'Video',
-            AudioCodec: transAudioCodecs,
+            AudioCodec: audioCodec,
             // When forceFmp4Hls is active the primary container is MP4, so we use
             // fmp4TransVideoCodecs (includes AV1/VP9). Otherwise it's MPEG-TS, which
             // cannot carry AV1/VP9, so we use the TS-restricted transVideoCodecs.
@@ -599,7 +609,11 @@ export function buildJellyfinProfile(options = {}) {
             // Setting this to false forces CBR AAC with ADTS framing on AVPlay.
             // HTML5/MSE players handle LATM fine, so keep VBR enabled there.
             EnableAudioVbrEncoding: isHtml5
-        },
+        });
+    }
+
+    // 2. Pure Audio transcoding profiles
+    transcodingProfiles.push(
         {
             Container: 'aac',
             Type: 'Audio',
@@ -615,21 +629,25 @@ export function buildJellyfinProfile(options = {}) {
             AudioCodec: 'mp3',
             Context: 'Streaming',
             Protocol: 'http'
-        },
+        }
+    );
 
-        {
+    // 3. Progressive HTTP video transcoding profile (one for each codec in transAudioCodecsArr)
+    for (const audioCodec of transAudioCodecsArr) {
+        transcodingProfiles.push({
             Container: 'mp4',
             Type: 'Video',
-            AudioCodec: transAudioCodecs,
+            AudioCodec: audioCodec,
             VideoCodec: transVideoCodecs,
             Context: 'Streaming',
             Protocol: 'http'
-        }
-        // Removed MKV and MP4 Static containers from TranscodingProfiles
-        // to force the server to always use HLS (segmented) streaming
-        // instead of progressive HTTP streams for transcodes,
-        // which Tizen AVPlay cannot reliably parse.
-    ];
+        });
+    }
+
+    // Removed MKV and MP4 Static containers from TranscodingProfiles
+    // to force the server to always use HLS (segmented) streaming
+    // instead of progressive HTTP streams for transcodes,
+    // which Tizen AVPlay cannot reliably parse.
 
     // -------------------------------------------------------------------------
     // Secondary fMP4 HLS profile (Tizen 6+ only by default)
@@ -638,28 +656,30 @@ export function buildJellyfinProfile(options = {}) {
     // If forceFmp4Hls is true, the primary profile above is already mp4, so
     // there is nothing extra to push here — avoid a duplicate.
     if (supportsFmp4Hls && !forceFmp4Hls) {
-        transcodingProfiles.push({
-            Container: 'mp4',
-            Type: 'Video',
-            // Use fmp4TransVideoCodecs here — this is the key difference from the TS profile.
-            // fMP4 (MP4 container) can carry AV1 and VP9, so we advertise them as copyable.
-            // This allows Jellyfin to pick this profile for AV1/VP9 sources with incompatible
-            // audio (e.g. DTS-HD MA): it will copy the video stream and only transcode audio.
-            AudioCodec: transAudioCodecs,
-            VideoCodec: fmp4TransVideoCodecs,
-            Context: 'Streaming',
-            Protocol: 'hls',
-            // On Tizen 6+ the transMaxAudioChannels is full surround (AC3/EAC3),
-            // which fMP4 HLS handles without issue.
-            MaxAudioChannels: transMaxAudioChannels,
-            MinSegments: isHtml5 ? 1 : 2,
-            SegmentLength: isHtml5
-                ? PlayerSettings.get('html5SegmentLength') || 2
-                : PlayerSettings.get('tizenSegmentLength') || 6,
-            // fMP4 segments MUST align to IDR boundaries — never cut on subtitle cue points.
-            BreakOnNonKeyFrames: false,
-            EnableAudioVbrEncoding: isHtml5
-        });
+        for (const audioCodec of transAudioCodecsArr) {
+            transcodingProfiles.push({
+                Container: 'mp4',
+                Type: 'Video',
+                // Use fmp4TransVideoCodecs here — this is the key difference from the TS profile.
+                // fMP4 (MP4 container) can carry AV1 and VP9, so we advertise them as copyable.
+                // This allows Jellyfin to pick this profile for AV1/VP9 sources with incompatible
+                // audio (e.g. DTS-HD MA): it will copy the video stream and only transcode audio.
+                AudioCodec: audioCodec,
+                VideoCodec: fmp4TransVideoCodecs,
+                Context: 'Streaming',
+                Protocol: 'hls',
+                // On Tizen 6+ the transMaxAudioChannels is full surround (AC3/EAC3),
+                // which fMP4 HLS handles without issue.
+                MaxAudioChannels: transMaxAudioChannels,
+                MinSegments: isHtml5 ? 1 : 2,
+                SegmentLength: isHtml5
+                    ? PlayerSettings.get('html5SegmentLength') || 2
+                    : PlayerSettings.get('tizenSegmentLength') || 6,
+                // fMP4 segments MUST align to IDR boundaries — never cut on subtitle cue points.
+                BreakOnNonKeyFrames: false,
+                EnableAudioVbrEncoding: isHtml5
+            });
+        }
     }
 
     const h264Level = caps.uhd ? '51' : '42'; // Spec sheets note: FHD models support Level 4.2

--- a/src/api/profiles/WebOSProfile.js
+++ b/src/api/profiles/WebOSProfile.js
@@ -565,30 +565,37 @@ export function buildJellyfinProfile(options = {}) {
     // Options: 'auto', 'prefer_ac3', 'prefer_aac', 'force_eac3', 'force_ac3', 'force_aac'.
     const preferredTranscodeCodec = PlayerSettings.get('transcodeAudioCodec') || 'auto';
 
-    let transAudioCodecsArr;
+    const transAudioCodecsArr = [];
     if (preferredTranscodeCodec === 'auto') {
         // Auto (Prefer E-AC3) -> E-AC3 first, then AC3, then AAC fallback
-        transAudioCodecsArr = ['eac3', 'ac3', 'aac'];
+        if (caps.eac3) transAudioCodecsArr.push('eac3');
+        if (caps.ac3) transAudioCodecsArr.push('ac3');
+        transAudioCodecsArr.push('aac');
     } else if (preferredTranscodeCodec === 'prefer_ac3') {
         // Prefer AC3 -> AC3 first, then E-AC3, then AAC fallback
-        transAudioCodecsArr = ['ac3', 'eac3', 'aac'];
+        if (caps.ac3) transAudioCodecsArr.push('ac3');
+        if (caps.eac3) transAudioCodecsArr.push('eac3');
+        transAudioCodecsArr.push('aac');
     } else if (preferredTranscodeCodec === 'prefer_aac') {
         // Prefer AAC -> AAC first, then E-AC3, then AC3
-        transAudioCodecsArr = ['aac', 'eac3', 'ac3'];
+        transAudioCodecsArr.push('aac');
+        if (caps.eac3) transAudioCodecsArr.push('eac3');
+        if (caps.ac3) transAudioCodecsArr.push('ac3');
     } else if (preferredTranscodeCodec === 'force_eac3') {
         // Only E-AC3
-        transAudioCodecsArr = ['eac3'];
+        transAudioCodecsArr.push('eac3');
     } else if (preferredTranscodeCodec === 'force_ac3') {
         // Only AC3
-        transAudioCodecsArr = ['ac3'];
+        transAudioCodecsArr.push('ac3');
+    } else if (preferredTranscodeCodec === 'force_mp3') {
+        // Only MP3
+        transAudioCodecsArr.push('mp3');    
     } else {
         // Only AAC
-        transAudioCodecsArr = ['aac'];
+        transAudioCodecsArr.push('aac');
     }
 
     // NOTE: DTS and TrueHD are deliberately NOT added here (see comment above).
-    const transAudioCodecs = transAudioCodecsArr.join(',');
-
     // ---------------------------------------------------------------------------
     // DirectStream audio codec list (DirectStreamProfiles).
     //
@@ -615,8 +622,11 @@ export function buildJellyfinProfile(options = {}) {
         transVideoCodecs = 'copy';
     }
 
-    const transcodingProfiles = [
-        {
+    const transcodingProfiles = [];
+
+    // Primary HLS video transcoding profile (one for each codec in transAudioCodecsArr)
+    for (const audioCodec of transAudioCodecsArr) {
+        transcodingProfiles.push({
             /*
              * Primary HLS video transcoding profile.
              *
@@ -635,7 +645,7 @@ export function buildJellyfinProfile(options = {}) {
              */
             Container: primaryHlsContainer,
             Type: 'Video',
-            AudioCodec: transAudioCodecs,
+            AudioCodec: audioCodec,
             VideoCodec: transVideoCodecs,
             Context: 'Streaming',
             Protocol: 'hls',
@@ -663,7 +673,11 @@ export function buildJellyfinProfile(options = {}) {
             // Exception: fMP4 is already forced-IDR by the muxer; and remux mode
             // passes the stream through as-is so we must not override it either.
             BreakOnNonKeyFrames: primaryHlsContainer === 'mp4' ? false : playbackMode === 'remux' ? false : false // always false for TS on WebOS
-        },
+        });
+    }
+
+    // Pure Audio transcoding profiles
+    transcodingProfiles.push(
         {
             Container: 'aac',
             Type: 'Audio',
@@ -686,7 +700,11 @@ export function buildJellyfinProfile(options = {}) {
             AudioCodec: 'opus',
             Context: 'Streaming',
             Protocol: 'http'
-        },
+        }
+    );
+
+    // Static transcoding profiles
+    transcodingProfiles.push(
         {
             Container: 'mkv',
             Type: 'Video',
@@ -703,7 +721,7 @@ export function buildJellyfinProfile(options = {}) {
             VideoCodec: enableHEVC ? 'h264,hevc' : 'h264',
             Context: 'Static'
         }
-    ];
+    );
 
     // -------------------------------------------------------------------------
     // Secondary fMP4 HLS profile
@@ -712,21 +730,23 @@ export function buildJellyfinProfile(options = {}) {
     // fMP4 is not already the primary container (no duplicate).
     // DOVI content no longer mandates fMP4 — it routes fine via TS.
     if (supportsFmp4Hls && primaryHlsContainer !== 'mp4') {
-        transcodingProfiles.push({
-            Container: 'mp4',
-            Type: 'Video',
-            AudioCodec: transAudioCodecs,
-            VideoCodec: transVideoCodecs,
-            Context: 'Streaming',
-            Protocol: 'hls',
-            MaxAudioChannels: maxAudioChannels,
-            MinSegments: 1,
-            SegmentLength: isHtml5
-                ? PlayerSettings.get('html5SegmentLength') || 2
-                : PlayerSettings.get('webosSegmentLength') || 6,
-            // fMP4 segments MUST align to IDR boundaries; never break on subtitle cue points.
-            BreakOnNonKeyFrames: false
-        });
+        for (const audioCodec of transAudioCodecsArr) {
+            transcodingProfiles.push({
+                Container: 'mp4',
+                Type: 'Video',
+                AudioCodec: audioCodec,
+                VideoCodec: transVideoCodecs,
+                Context: 'Streaming',
+                Protocol: 'hls',
+                MaxAudioChannels: maxAudioChannels,
+                MinSegments: 1,
+                SegmentLength: isHtml5
+                    ? PlayerSettings.get('html5SegmentLength') || 2
+                    : PlayerSettings.get('webosSegmentLength') || 6,
+                // fMP4 segments MUST align to IDR boundaries; never break on subtitle cue points.
+                BreakOnNonKeyFrames: false
+            });
+        }
     }
 
     // H.264 levels: 5.1 for UHD, 4.1 for 1080p

--- a/src/api/profiles/WebProfile.js
+++ b/src/api/profiles/WebProfile.js
@@ -340,7 +340,7 @@ export function buildJellyfinProfile(options = {}) {
     // from transcoding to a codec the player truly cannot handle.
     // -------------------------------------------------------------------------
     const preferredTranscodeCodec = PlayerSettings.get('transcodeAudioCodec') || 'auto';
-    let transAudioCodecsArr = [];
+    const transAudioCodecsArr = [];
 
     if (preferredTranscodeCodec === 'auto') {
         // Auto (Prefer E-AC3)
@@ -368,8 +368,6 @@ export function buildJellyfinProfile(options = {}) {
         transAudioCodecsArr.push('aac');
     }
 
-    let transAudioCodecs = transAudioCodecsArr.join(',');
-
     let transVideoCodecs = enableHEVC ? 'h264,hevc' : 'h264';
 
     if (playbackMode === 'remux') {
@@ -383,11 +381,14 @@ export function buildJellyfinProfile(options = {}) {
         .filter(Boolean)
         .join(',');
 
-    const transcodingProfiles = [
-        {
+    const transcodingProfiles = [];
+
+    // Primary HLS video transcoding profile (one for each codec in transAudioCodecsArr)
+    for (const audioCodec of transAudioCodecsArr) {
+        transcodingProfiles.push({
             Container: 'mp4',
             Type: 'Video',
-            AudioCodec: transAudioCodecs,
+            AudioCodec: audioCodec,
             VideoCodec: broadTransVideo,
             Context: 'Streaming',
             Protocol: 'hls',
@@ -395,11 +396,15 @@ export function buildJellyfinProfile(options = {}) {
             MinSegments: '2',
             SegmentLength: String(PlayerSettings.get('html5SegmentLength') || 2),
             BreakOnNonKeyFrames: playbackMode !== 'remux'
-        },
-        {
+        });
+    }
+
+    // Secondary HLS video transcoding profile (one for each codec in transAudioCodecsArr)
+    for (const audioCodec of transAudioCodecsArr) {
+        transcodingProfiles.push({
             Container: 'ts',
             Type: 'Video',
-            AudioCodec: transAudioCodecs,
+            AudioCodec: audioCodec,
             VideoCodec: transVideoCodecs,
             Context: 'Streaming',
             Protocol: 'hls',
@@ -407,7 +412,11 @@ export function buildJellyfinProfile(options = {}) {
             MinSegments: '2',
             SegmentLength: String(PlayerSettings.get('html5SegmentLength') || 2),
             BreakOnNonKeyFrames: playbackMode !== 'remux'
-        },
+        });
+    }
+
+    // Pure Audio transcoding profiles
+    transcodingProfiles.push(
         {
             Container: 'aac',
             Type: 'Audio',
@@ -431,7 +440,7 @@ export function buildJellyfinProfile(options = {}) {
             Context: 'Streaming',
             Protocol: 'http'
         }
-    ];
+    );
 
     // Relaxed levels for HTML5/MSE
     const h264Level = '51';

--- a/src/api/profiles/WebProfile.js
+++ b/src/api/profiles/WebProfile.js
@@ -363,6 +363,9 @@ export function buildJellyfinProfile(options = {}) {
     } else if (preferredTranscodeCodec === 'force_ac3') {
         // Only AC3
         transAudioCodecsArr.push('ac3');
+    } else if (preferredTranscodeCodec === 'force_mp3') {
+        // Only MP3
+        transAudioCodecsArr.push('mp3');    
     } else {
         // Only AAC (force_aac)
         transAudioCodecsArr.push('aac');

--- a/src/locales/en-gb.json
+++ b/src/locales/en-gb.json
@@ -1073,6 +1073,7 @@
     "TranscodeAudioCodecDescription": "When audio must be transcoded (e.g. DTS is unsupported), use this codec. E-AC3 is higher quality; AC3 has the widest legacy receiver support; AAC is the universal fallback.",
     "TranscodeCodecAuto": "Auto (Prefer E-AC3)",
     "TranscodeCodecForceAac": "Only AAC",
+    "TranscodeCodecForceMp3": "Only MP3",
     "TranscodeCodecForceAc3": "Only AC3",
     "TranscodeCodecForceEac3": "Only E-AC3",
     "TranscodeCodecPreferAac": "Prefer AAC",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -1077,6 +1077,7 @@
     "TranscodeAudioCodecDescription": "When audio must be transcoded (e.g. DTS is unsupported), use this codec. E-AC3 is higher quality; AC3 has the widest legacy receiver support; AAC is the universal fallback.",
     "TranscodeCodecAuto": "Auto (Prefer E-AC3)",
     "TranscodeCodecForceAac": "Only AAC",
+    "TranscodeCodecForceMp3": "Only MP3",
     "TranscodeCodecForceAc3": "Only AC3",
     "TranscodeCodecForceEac3": "Only E-AC3",
     "TranscodeCodecPreferAac": "Prefer AAC",

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -1073,6 +1073,7 @@
     "TranscodeAudioCodecDescription": "When audio must be transcoded (e.g. DTS is unsupported), use this codec. E-AC3 is higher quality; AC3 has the widest legacy receiver support; AAC is the universal fallback.",
     "TranscodeCodecAuto": "Auto (Prefer E-AC3)",
     "TranscodeCodecForceAac": "Only AAC",
+    "TranscodeCodecForceMp3": "Only MP3",
     "TranscodeCodecForceAc3": "Only AC3",
     "TranscodeCodecForceEac3": "Only E-AC3",
     "TranscodeCodecPreferAac": "Prefer AAC",

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -28,10 +28,9 @@ import { homeLayoutManager } from '../utils/HomeLayoutManager.js';
 import { sidebarLayoutManager } from '../utils/SidebarLayoutManager.js';
 import { eventBus } from '../core/EventBus.js';
 import { versionChecker } from '../utils/VersionChecker.js';
-import { settingsIcons } from '../utils/Icons.js';
+import { settingsIcons, setIconStyle, getSupportedStyles } from '../utils/Icons.js';
 import { pinManager } from '../utils/PinManager.js';
 import { pinDialog } from '../ui/PinDialog.js';
-import { setIconStyle, getSupportedStyles } from '../utils/Icons.js';
 
 const log = logger.create('SettingsPage');
 
@@ -2855,7 +2854,8 @@ class SettingsPage extends Page {
                     { value: 'prefer_aac', label: i18n.t('TranscodeCodecPreferAac') || 'Prefer AAC' },
                     { value: 'force_eac3', label: i18n.t('TranscodeCodecForceEac3') || 'Only E-AC3' },
                     { value: 'force_ac3', label: i18n.t('TranscodeCodecForceAc3') || 'Only AC3' },
-                    { value: 'force_aac', label: i18n.t('TranscodeCodecForceAac') || 'Only AAC' }
+                    { value: 'force_aac', label: i18n.t('TranscodeCodecForceAac') || 'Only AAC' },
+                    { value: 'force_mp3', label: i18n.t('TranscodeCodecForceMp3') || 'Only MP3' }
                 ],
                 PlayerSettings.get('transcodeAudioCodec') || 'auto'
             )}

--- a/src/utils/PlayerSettings.js
+++ b/src/utils/PlayerSettings.js
@@ -76,8 +76,9 @@ const DEFAULTS = {
     //   'force_eac3'  — Force/Only E-AC3.
     //   force_ac3'   — Force/Only AC3.
     //   'force_aac'   — Force/Only AAC.
-    //
-    // NOTE: This only affects HLS transcode output. DirectPlay/DirectStream paths
+    //   'force_mp3'   — Force/Only MP3.
+    //                   
+    // NOTE: This only affects HLS transcode output.DirectPlay/DirectStream paths
     // bypass this entirely — the source audio is copied as-is in those cases.
     transcodeAudioCodec: 'auto',
 


### PR DESCRIPTION

## Description

Jellyfin's Mediaencoder uses the CanEncodeToAudioCodec method to check the audio codec profiles sent by the client, but it doesn't support codec profiles list separated by commas and reject the profile and fell back to default AAC/AC3. Which clearly explains why our only ac3/only eac3/only aac worked since we are sending single codec string without any split required by jellyfin unlike videocodec which supports the comma splitted list. So, instead of using the join logic the profile builders now loop over transAudioCodecsArr and push a separate, distinct transcoding profile object to the server for each codec in order of preference respecting user setting.

Also implemented the already using device capability filtering (caps.eac3/caps.ac3) in the web profile to both Tizen and webOS profile apart from the OS version gate. So, this ensures that the client isn't sending any unsupported audio codec profiles to the server thereby reducing chances of playback failure.

Consolidated multiple duplicate import statements from Icons.js into a single clean import, fixing no-duplicate-imports lint errors.

Added a new force_mp3 option to the audio transcoding preferences list under Settings.
Code changes suggested by Google's Antigravity AI, reviewed and tested by me.

Fixes #207 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Tested the build in Tizen TV and webOS emulator and everything works as intended. Especially in webOS emulator which doesn't support ac3/eac3 audio codecs, when we choose the default Auto(prefer eac3) option, it correctly fallbacks to aac codec during hls transcodes.
It will be helpful if someone tested this in LG TV too confirming the changes.

- **Platform**: [e.g. Tizen, webOS]
- **Device Model**: [UA55DU7000KLXL]
- **Build Variant Tested**: [ES6]

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added appropriate JSDoc comments
