### PR TITLE
Removed force_mp3 in webprofile

### DIFF
--- a/src/api/profiles/WebProfile.js
+++ b/src/api/profiles/WebProfile.js
@@ -393,9 +393,6 @@ export function buildJellyfinProfile(options = {}) {
     } else if (preferredTranscodeCodec === 'force_ac3') {
         // Only AC3
         transAudioCodecsArr.push('ac3');
-    } else if (preferredTranscodeCodec === 'force_mp3') {
-        // Only MP3
-        transAudioCodecsArr.push('mp3');    
     } else {
         // Only AAC (force_aac)
         transAudioCodecsArr.push('aac');


### PR DESCRIPTION
## Description

Removed force_mp3 option for webprofile as it crashes on web browsers.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Tested in Edge Browser.

- **Platform**: [Web]
- **Build Variant Tested**: [ES6]

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added appropriate JSDoc comments
