### PR TITLE
fix(player): use full Jellyfin auth header for playback

### DIFF
--- a/src/player/core/JellyfinPlayer.js
+++ b/src/player/core/JellyfinPlayer.js
@@ -2503,7 +2503,7 @@ export class JellyfinPlayer extends EventEmitter {
             }
         } else {
             // Standard Jellyfin Authorization format
-            headers['Authorization'] = `MediaBrowser Token="${this.authToken}"`;
+            headers['Authorization'] = api.getAuthHeader(this.authToken);
         }
 
         const response = await fetch(url, {


### PR DESCRIPTION
## Description

  Use Litefin's existing `getAuthHeader()` helper for the PlaybackInfo request instead of sending a token-only authorization header.

  The token-only header caused Jellyswarrm to return HTTP 401 during playback, even though login and browsing worked. The full authorization header fixes playback and is already used by
  Litefin's other API requests.

  Related issue: None filed in Litefin.

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Documentation update
  - [ ] Refactoring

  ## How Has This Been Tested?

  Built and sideloaded the patched webOS IPK. Playback through Jellyswarrm returned HTTP 401 before the change and works correctly after the change.

  - **Platform**: webOS
  - **Device Model**: 55UQ8000PSB
  - **Build Variant Tested**: Normal

  ## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] Documentation changes are not required for this fix
  - [x] My changes generate no new warnings
  - [x] JSDoc changes are not required because no API was added or changed

  ## Screenshots (if applicable)

  Not applicable; this change does not affect the UI.