### PR TITLE
fix: lowercase url parameter causing 0 search results

### DIFF
--- a/src/api/ApiClient.js
+++ b/src/api/ApiClient.js
@@ -166,8 +166,8 @@ export class ApiClient {
         if (this.isEmby()) {
             /*
              * Emby auth header format uses the 'Emby' scheme.
-             * It requires 'UserId' (if authenticated) but does NOT carry the 
-             * 'Token' inside the Authorization header itself. Instead, the token 
+             * It requires 'UserId' (if authenticated) but does NOT carry the
+             * 'Token' inside the Authorization header itself. Instead, the token
              * is transmitted in the separate 'X-Emby-Token' request header.
              */
             const parts = [
@@ -1071,7 +1071,7 @@ export class ApiClient {
     async searchPeople(query, params = {}) {
         const defaults = {
             UserId: this._userId,
-            searchTerm: query,
+            SearchTerm: query,
             Limit: 24,
             Fields: 'PrimaryImageAspectRatio',
             Recursive: true,
@@ -1159,11 +1159,11 @@ export class ApiClient {
         // Map max constraints
         if (options.maxWidth) params.append('maxWidth', options.maxWidth);
         if (options.maxHeight) params.append('maxHeight', options.maxHeight);
-        
+
         // Map fill constraints (contain style aspect preservation)
         if (options.fillWidth) params.append('fillWidth', options.fillWidth);
         if (options.fillHeight) params.append('fillHeight', options.fillHeight);
-        
+
         // Map quality and unique content tags
         if (options.quality) params.append('quality', options.quality);
         if (options.tag) params.append('tag', options.tag);
@@ -1182,11 +1182,11 @@ export class ApiClient {
         // Map max constraints
         if (options.maxWidth) params.append('maxWidth', options.maxWidth);
         if (options.maxHeight) params.append('maxHeight', options.maxHeight);
-        
+
         // Map fill constraints (contain style aspect preservation)
         if (options.fillWidth) params.append('fillWidth', options.fillWidth);
         if (options.fillHeight) params.append('fillHeight', options.fillHeight);
-        
+
         // Map quality settings
         if (options.quality) params.append('quality', options.quality);
 


### PR DESCRIPTION
## Description

"searchTerm" beginning with a lowercase character prevents some jellyfin server [variations](https://github.com/lostb1t/remux) to interpret the URL parameter, thus returning 0 results.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- **Platform**: webOS
- **Device Model**: 50UM7510PSB
- **Build Variant Tested**: Legacy

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation accordingly
- [X] My changes generate no new warnings
- [X] I have added appropriate JSDoc comments

## Screenshots (if applicable)

If this PR changes the UI, please provide screenshots.
