### PR TITLE
Make libaas-wasm renderAhead buffer size configurable, and default to 90MB

### DIFF
--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -396,6 +396,8 @@
     "AssFontFamily": "ASS Format Font Family",
     "AssPrescaleFactor": "Subtitle Canvas Scale",
     "AssPrescaleFactorDescription": "Lower = better performance but softer text (1.0 = full resolution).",
+    "AssRenderAhead": "Subtitle Pre-render Buffer",
+    "AssRenderAheadDescription": "Memory for pre-rendered subtitles. Larger = smoother complex typesetting (big signs, masks), smaller = less memory use.",
     "AssRenderer": "ASS Subtitle Renderer",
     "AssRendererDescription": "Choose the rendering engine for ASS/SSA subtitle styling.",
     "Auto": "Auto",

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -4014,6 +4014,27 @@ class SettingsPage extends Page {
                     </div>
                 </div>
 
+                <div class="setting-item" id="ass-render-ahead-container" style="display: ${PlayerSettings.get('assRenderer') === 'libass-wasm' ? '' : 'none'}">
+                    <div class="setting-label">
+                        <span class="setting-name" data-i18n="AssRenderAhead">${i18n.t('AssRenderAhead') || 'Subtitle Pre-render Buffer'}</span>
+                        <span class="setting-description" data-i18n="AssRenderAheadDescription">${i18n.t('AssRenderAheadDescription') || 'Memory for pre-rendered subtitles. Larger = smoother complex typesetting (big signs, masks), smaller = less memory use.'}</span>
+                    </div>
+                    <div class="setting-control">
+                        ${this._renderDropdown(
+            'ass-render-ahead-select',
+            [
+                { value: 30, label: '30 MB (lowest memory)' },
+                { value: 50, label: '50 MB' },
+                { value: 70, label: '70 MB' },
+                { value: 90, label: '90 MB (recommended)' },
+                { value: 120, label: '120 MB' },
+                { value: 150, label: '150 MB (largest buffer)' }
+            ],
+            PlayerSettings.get('subtitleAssRenderAhead')
+        )}
+                    </div>
+                </div>
+
                 <div class="setting-item">
                     <div class="setting-label">
                         <span class="setting-name" data-i18n="LabelPgsPlaybackMode">${i18n.t('LabelPgsPlaybackMode') || 'PGS Subtitle Engine'}</span>
@@ -7572,6 +7593,7 @@ class SettingsPage extends Page {
             'subtitle-font-ass-select': { key: 'subtitleFontAss', type: 'player' },
             'ass-renderer-select': { key: 'assRenderer', type: 'player' },
             'ass-prescale-factor-select': { key: 'subtitleAssPrescaleFactor', type: 'player' },
+            'ass-render-ahead-select': { key: 'subtitleAssRenderAhead', type: 'player' },
             'subtitle-color-select': { key: 'subtitleTextColor', type: 'player' },
             'subtitle-color-select-hdr': { key: 'subtitleTextColorHdr', type: 'player' },
             'subtitle-shadow-select': { key: 'subtitleDropShadow', type: 'player' },
@@ -7907,7 +7929,8 @@ class SettingsPage extends Page {
                                 'tizenSegmentLength',
                                 'html5MaxBufferLength',
                                 'html5MaxMaxBufferLength',
-                                'html5SegmentLength'
+                                'html5SegmentLength',
+                                'subtitleAssRenderAhead'
                             ];
 
                             let val = newValue;
@@ -7929,8 +7952,10 @@ class SettingsPage extends Page {
                                 const isLibass = newValue === 'libass-wasm';
                                 const animContainer = this.$('#ass-drop-animations-container');
                                 const scaleContainer = this.$('#ass-prescale-factor-container');
+                                const renderAheadContainer = this.$('#ass-render-ahead-container');
                                 if (animContainer) animContainer.style.display = isLibass ? '' : 'none';
                                 if (scaleContainer) scaleContainer.style.display = isLibass ? '' : 'none';
+                                if (renderAheadContainer) renderAheadContainer.style.display = isLibass ? '' : 'none';
                                 focusManager.invalidateCache('settings-content');
                             }
 

--- a/src/player/core/LibassWasmRenderer.js
+++ b/src/player/core/LibassWasmRenderer.js
@@ -278,7 +278,7 @@ export default class LibassWasmRenderer {
                 prescaleHeightLimit: 1080,
                 maxRenderHeight: maxHeight,
                 resizeVariation: 0.2,
-                renderAhead: this._isVirtual ? 100 : 50
+                renderAhead: this._isVirtual ? 100 : 90
             };
 
             this._octopus = new SubtitlesOctopus(options);

--- a/src/player/core/LibassWasmRenderer.js
+++ b/src/player/core/LibassWasmRenderer.js
@@ -257,6 +257,7 @@ export default class LibassWasmRenderer {
 
             const dropAnimations = PlayerSettings.get('subtitleAssDropAnimations') === true;
             const prescaleFactor = parseFloat(PlayerSettings.get('subtitleAssPrescaleFactor')) || 0.8;
+            const renderAhead = parseInt(PlayerSettings.get('subtitleAssRenderAhead'), 10) || 90;
             const maxHeight = Math.min(2160, typeof screen !== 'undefined' ? (screen.height || 1080) : 1080);
 
             const options = {
@@ -278,7 +279,7 @@ export default class LibassWasmRenderer {
                 prescaleHeightLimit: 1080,
                 maxRenderHeight: maxHeight,
                 resizeVariation: 0.2,
-                renderAhead: this._isVirtual ? 100 : 90
+                renderAhead: this._isVirtual ? 100 : renderAhead
             };
 
             this._octopus = new SubtitlesOctopus(options);

--- a/src/utils/PlayerSettings.js
+++ b/src/utils/PlayerSettings.js
@@ -178,6 +178,11 @@ const DEFAULTS = {
     // Scale down the subtitle canvas to improve performance (1.0 = full res)
     subtitleAssPrescaleFactor: 0.8,
 
+    // Pre-render buffer size in MB for libass-wasm (HTML5 path). Octopus skips
+    // caching any single event larger than renderAhead * 0.3, so low values
+    // force large \p1 vector drawings to re-render every frame
+    subtitleAssRenderAhead: 90,
+
     // Global font scale multiplier for ASS subtitles
     subtitleFontScale: 1.0,
 


### PR DESCRIPTION
See #294. Changes the default buffer size from 50MB to 90MB, and adds a new option for it under Subtitles settings menu.  Tested on LG C5.

Note: this PR is fully vibecoded, feel free to adopt/reuse/commandeer/close as prefererd.