### PR TITLE
feat(osd): add option to only show the OSD on OK press

### DIFF
--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -208,6 +208,8 @@
     "NoOptionsAvailable": "No options available",
     "Normal": "Normal",
     "Off": "Off",
+    "OkShowOsdOnly": "OK Shows OSD Only",
+    "OkShowOsdOnlyDescription": "When the player controls are hidden, pressing OK will only show them instead of also running the focused action.",
     "Option3D": "3D",
     "OptionBluray": "BD",
     "OptionDateAdded": "Date Added",

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -3156,6 +3156,20 @@ class SettingsPage extends Page {
 
                 <div class="setting-item">
                     <div class="setting-label">
+                        <span class="setting-name" data-i18n="OkShowOsdOnly">${i18n.t('OkShowOsdOnly') || 'OK Shows OSD Only'}</span>
+                        <span class="setting-description" data-i18n="OkShowOsdOnlyDescription">${i18n.t('OkShowOsdOnlyDescription') || 'When the player controls are hidden, pressing OK will only show them instead of also running the focused action.'}</span>
+                    </div>
+                    <div class="setting-control">
+                        <button class="toggle-switch ${PlayerSettings.get('okShowOsdOnly') ? 'active' : ''}"
+                                id="toggle-ok-show-osd-only"
+                                data-setting="okShowOsdOnly"
+                                tabindex="0">
+                        </button>
+                    </div>
+                </div>
+
+                <div class="setting-item">
+                    <div class="setting-label">
                         <span class="setting-name" data-i18n="KeepFocusOnSubtitleOffset">${i18n.t('KeepFocusOnSubtitleOffset') || 'Pin Subtitle Offset'}</span>
                         <span class="setting-description" data-i18n="KeepFocusOnSubtitleOffsetDescription">${i18n.t('KeepFocusOnSubtitleOffsetDescription') || 'Prevent the player controls from auto-hiding while the subtitle offset menu is open.'}</span>
                     </div>
@@ -6792,6 +6806,18 @@ class SettingsPage extends Page {
                 const newValue = !currentValue;
                 PlayerSettings.set('osdHideShowName', newValue);
                 hideShowNameBtn.classList.toggle('active', newValue);
+            });
+        }
+
+        // Toggle OK Shows OSD Only (don't execute the focused action, e.g.
+        // Play/Pause, on the OK press that wakes a hidden OSD)
+        const okShowOsdOnlyBtn = this.$('#toggle-ok-show-osd-only');
+        if (okShowOsdOnlyBtn) {
+            okShowOsdOnlyBtn.addEventListener('click', () => {
+                const currentValue = PlayerSettings.get('okShowOsdOnly');
+                const newValue = !currentValue;
+                PlayerSettings.set('okShowOsdOnly', newValue);
+                okShowOsdOnlyBtn.classList.toggle('active', newValue);
             });
         }
 

--- a/src/player/osd/OSDController.js
+++ b/src/player/osd/OSDController.js
@@ -1644,8 +1644,17 @@ export default class OSDController extends Component {
              * Since we discard the TV browser's synthesized ghost clicks globally
              * to prevent double-execution, we must execute the focused action
              * entirely in JavaScript during the wake-up sequence.
+             *
+             * EXCEPTION: when the "okShowOsdOnly" setting is enabled, this
+             * dispatch is skipped for the main OSD rows (Play/Pause, seekbar, back)
+             * so the first OK press only reveals the controls — the user must press
+             * OK again once the desired button holds focus. Overlay widgets (Row -1,
+             * e.g. skip-intro/up-next) are unaffected: those are transient prompts
+             * where OK is expected to act immediately.
              * ========================================================================
              */
+            const showOsdOnly = PlayerSettings.get('okShowOsdOnly') === true;
+
             if (this._currentFocusRow === -1) {
                 // Overlay row (Row -1): a plugin widget (e.g. skip-intro) holds focus.
                 // The widget's container has a click listener registered by PluginWidgetHost
@@ -1679,29 +1688,34 @@ export default class OSDController extends Component {
                 }
 
                 // Widget is hidden/gone — recover: reset row to controls and
-                // execute play/pause as the user's intent for this wakeup press.
+                // execute play/pause as the user's intent for this wakeup press
+                // (unless the wake-up press is only supposed to show the controls).
                 this._currentFocusRow = 1;
                 const playIdx = this._findActionIndex('togglePlay');
                 if (playIdx !== -1) this._currentFocusIndex = playIdx;
                 this._updateFocus();
-                this._executeAction('togglePlay');
+                if (!showOsdOnly) this._executeAction('togglePlay');
             } else if (this._currentFocusRow === 2) {
                 // Seekbar row: OK = toggle play/pause
-                this._executeAction('togglePlay');
+                if (!showOsdOnly) this._executeAction('togglePlay');
             } else if (this._currentFocusRow === 1) {
                 // Controls row: execute focused action (e.g. play/pause or subtitles)
-                const controls = this._getControls();
-                const btn = controls[Math.min(this._currentFocusIndex, controls.length - 1)];
-                if (btn?.dataset?.action) {
-                    this._executeAction(btn.dataset.action);
+                if (!showOsdOnly) {
+                    const controls = this._getControls();
+                    const btn = controls[Math.min(this._currentFocusIndex, controls.length - 1)];
+                    if (btn?.dataset?.action) {
+                        this._executeAction(btn.dataset.action);
+                    }
                 }
             } else if (this._currentFocusRow === 0) {
                 // Header row (back button)
-                const btn = this._cachedHeaderRow[0];
-                if (btn?.dataset?.action) {
-                    this._executeAction(btn.dataset.action);
-                } else {
-                    this._executeAction('exit');
+                if (!showOsdOnly) {
+                    const btn = this._cachedHeaderRow[0];
+                    if (btn?.dataset?.action) {
+                        this._executeAction(btn.dataset.action);
+                    } else {
+                        this._executeAction('exit');
+                    }
                 }
             }
 

--- a/src/utils/PlayerSettings.js
+++ b/src/utils/PlayerSettings.js
@@ -469,6 +469,25 @@ const DEFAULTS = {
      */
     osdFocusRestoreMode: 'always',
 
+    /*
+     * OK/Enter Wake-Up Behavior
+     * -------------------------------------------------------------------------
+     * Whether the OK/Enter press that reveals a hidden OSD only shows the
+     * controls, instead of also running the action that holds focus at that
+     * moment. Only affects that first wake-up press — once the controls are
+     * visible, OK always runs the focused action regardless of this setting.
+     *
+     *   false (default) — Reveals the OSD AND runs the pre-parked focused
+     *                     action, which is Play/Pause by default. This means
+     *                     the very first OK press during playback pauses the
+     *                     video.
+     *   true            — Reveals the controls only. No action runs on that
+     *                     first press; the user presses OK again once the
+     *                     desired button holds focus. Prevents accidentally
+     *                     pausing playback just to check the floating controls.
+     */
+    okShowOsdOnly: false,
+
     // Keep focus on subtitle offset menu (prevent auto-hide)
     keepFocusOnSubtitleOffset: true,
 


### PR DESCRIPTION
## Description

Current behavior is that pressing OK/Enter while watching a movie reveals controls AND pauses. It's a very confusing and annoying behavior and a big change from the default Jellyfin client. Often I just want to change subtitles/audio track or just see where I am progress-wise, so it's very inconvenient that it pauses all the time.

This PR adds a feature flag to reveal OSD on the first OK click, so that the second click is needed to run the action. I tested it and it works like a charm.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- **Platform**: Tizen
- **Device Model**: UE50AU7105
- **Build Variant Tested**: Normal

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added appropriate JSDoc comments
