### PR TITLE
fix(player): Fix resume button playing from start instead of resuming

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -2284,41 +2284,47 @@ class DetailsPage extends Page {
             }
         }
 
-        // Upgrade to primary style
-        resumeBtn.classList.remove('btn-secondary');
-        resumeBtn.classList.add('btn-primary');
+        // The label/style/focus handoff below only applies when Resume is actually
+        // the active button (i.e. a resume point exists) — guard it the same way
+        // visibility was gated above so it doesn't steal focus from Play when there's
+        // nothing to resume.
+        if (userData.PlaybackPositionTicks > 0) {
+            // Upgrade to primary style
+            resumeBtn.classList.remove('btn-secondary');
+            resumeBtn.classList.add('btn-primary');
 
-        // Retrieve the resume position from UserData playback position.
-        // Convert playback ticks to total minutes. Note that 1 minute is equivalent to 600,000,000 ticks.
-        const resumeTime = Math.round(userData.PlaybackPositionTicks / 600000000);
+            // Retrieve the resume position from UserData playback position.
+            // Convert playback ticks to total minutes. Note that 1 minute is equivalent to 600,000,000 ticks.
+            const resumeTime = Math.round(userData.PlaybackPositionTicks / 600000000);
 
-        // Define a variable to store our sleekly formatted timestamp string.
-        let timeString = '';
+            // Define a variable to store our sleekly formatted timestamp string.
+            let timeString = '';
 
-        // Check if the user has watched past 59 minutes (i.e. at least 60 minutes).
-        // If so, we format the time using a premium hour-and-minute pattern (e.g., "1h 15m").
-        if (resumeTime >= 60) {
-            // Compute the absolute number of whole hours.
-            const hours = Math.floor(resumeTime / 60);
-            // Calculate the remaining minutes left over.
-            const minutes = resumeTime % 60;
+            // Check if the user has watched past 59 minutes (i.e. at least 60 minutes).
+            // If so, we format the time using a premium hour-and-minute pattern (e.g., "1h 15m").
+            if (resumeTime >= 60) {
+                // Compute the absolute number of whole hours.
+                const hours = Math.floor(resumeTime / 60);
+                // Calculate the remaining minutes left over.
+                const minutes = resumeTime % 60;
 
-            // Format the string elegantly. If there are no remaining minutes (e.g. exactly 1 hour),
-            // show only the hour to maintain a clean and beautiful minimal aesthetic.
-            timeString = minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
-        } else {
-            // Under 60 minutes, display in simple minute format (e.g., "45m").
-            timeString = `${resumeTime}m`;
+                // Format the string elegantly. If there are no remaining minutes (e.g. exactly 1 hour),
+                // show only the hour to maintain a clean and beautiful minimal aesthetic.
+                timeString = minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+            } else {
+                // Under 60 minutes, display in simple minute format (e.g., "45m").
+                timeString = `${resumeTime}m`;
+            }
+
+            // Apply localization to the formatted time label to construct the full button label text.
+            const resumeLabel = i18n.t('ResumeAt', [timeString]);
+
+            // Update the inner HTML of the resume button with a play icon and the formatted label.
+            resumeBtn.innerHTML = `${detailsIcons.play} <span>${resumeLabel}</span>`;
+
+            // We hid the Play button, so move focus to the Resume button.
+            resumeBtn.focus();
         }
-
-        // Apply localization to the formatted time label to construct the full button label text.
-        const resumeLabel = i18n.t('ResumeAt', [timeString]);
-
-        // Update the inner HTML of the resume button with a play icon and the formatted label.
-        resumeBtn.innerHTML = `${detailsIcons.play} <span>${resumeLabel}</span>`;
-
-        // If we hid the Play button, try to move focus to the Resume button.
-        resumeBtn.focus();
 
         // Watched button
         if (watchedBtn) {

--- a/src/ui/FocusManager.js
+++ b/src/ui/FocusManager.js
@@ -153,10 +153,18 @@ class FocusManager {
 
         // Track focus changes globally
         document.addEventListener('focusin', (e) => {
+            // NOTE: Page.setLoading(false) only removes the 'loading' class from the
+            // page root — it never removes the '.page-loading' overlay div itself, so
+            // that element stays in the DOM (just CSS-hidden via display:none) for the
+            // rest of the page's lifetime. Checking for its mere presence therefore
+            // treats the page as "loading" forever after the first spinner, silently
+            // dropping every subsequent focusin (e.g. DetailsPage's resumeBtn.focus()),
+            // so we must also verify it's actually visible before treating it as active.
+            const pageLoadingEl = document.querySelector('.page-loading');
             const isPageLoading =
                 document.body.classList.contains('app-splash-active') ||
                 document.querySelector('.page.loading') ||
-                document.querySelector('.page-loading');
+                (pageLoadingEl && getComputedStyle(pageLoadingEl).display !== 'none');
 
             if (isPageLoading) {
                 const sectionName = this.getSectionForElement(e.target);


### PR DESCRIPTION
## Description

Fixes the issue when Resume starts movie from the beginning. Tested locally, it solves the problem.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- **Platform**: Tizen
- **Device Model**: UE50AU7105
- **Build Variant Tested**: Normal

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added appropriate JSDoc comments