### PR TITLE
fix(player): Fix resume does not work in certain scenario

### DIFF
--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -586,6 +586,16 @@ class DetailsPage extends Page {
                 this._deferredLoading = true;
             } else {
                 this.setLoading(false);
+
+                // No restore target, so the page is about to become interactive right
+                // now — before secondary content (cast, similar, collections) below has
+                // even started loading. Force focus onto Resume immediately rather than
+                // waiting for the deferred block further down, which only runs once all
+                // of that secondary content finishes. Otherwise there's a multi-second
+                // window where the page looks ready but focus is still on the default
+                // Play button, and a fast OK press starts playback from scratch instead
+                // of resuming.
+                this._resumeFocusForced = this._focusResumeButton();
             }
 
             // ────────────────────────────────────────────────────────────────────────
@@ -673,12 +683,8 @@ class DetailsPage extends Page {
                         // triggers the base-class restore itself, and the Resume-button
                         // fallback below would be skipped without ever taking its place.
                         this.restoreScrollFocusWhenReady();
-                    } else if (this._item.UserData?.PlaybackPositionTicks > 0) {
-                        const resumeBtn = this.$('.resume-btn');
-                        if (resumeBtn && !resumeBtn.classList.contains('hidden')) {
-                            log.info('Forcing focus to Resume button');
-                            focusManager.focusElement(resumeBtn);
-                        }
+                    } else if (!this._resumeFocusForced) {
+                        this._focusResumeButton();
                     }
                 }
 
@@ -696,6 +702,21 @@ class DetailsPage extends Page {
             this.showError(i18n.t('FailedToLoadDetails'));
             this.setLoading(false);
         }
+    }
+
+    /**
+     * Focus the Resume button if the item has playback progress and the button
+     * is visible. Returns whether focus was actually forced.
+     */
+    _focusResumeButton() {
+        if (!(this._item.UserData?.PlaybackPositionTicks > 0)) return false;
+
+        const resumeBtn = this.$('.resume-btn');
+        if (!resumeBtn || resumeBtn.classList.contains('hidden')) return false;
+
+        log.info('Forcing focus to Resume button');
+        focusManager.focusElement(resumeBtn);
+        return true;
     }
 
     _showVersionSelectionMenu() {

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -665,8 +665,15 @@ class DetailsPage extends Page {
                     state.delete(stateKey);
                 }
 
-                if (!restoredFocus && !this._pendingNavState) {
-                    if (this._item.UserData?.PlaybackPositionTicks > 0) {
+                if (!restoredFocus) {
+                    if (this._pendingNavState) {
+                        // A Back-navigation left us a section/index to restore (e.g.
+                        // returning from Settings via the sidebar). Consume it now —
+                        // otherwise it just sits here forever, since DetailsPage never
+                        // triggers the base-class restore itself, and the Resume-button
+                        // fallback below would be skipped without ever taking its place.
+                        this.restoreScrollFocusWhenReady();
+                    } else if (this._item.UserData?.PlaybackPositionTicks > 0) {
                         const resumeBtn = this.$('.resume-btn');
                         if (resumeBtn && !resumeBtn.classList.contains('hidden')) {
                             log.info('Forcing focus to Resume button');


### PR DESCRIPTION
## Description

Scenario 1:

Fixes issue from the [comment](https://github.com/MoazSalem/litefin/pull/313#issuecomment-5241175909)

> Actually, I too had this issue in my TV. The way to trigger it was, close movie midway and use the sidebar to open any menu and then come back to details page. Now if you press the resume button movie will start from beginning. To avoid this, you have to move the focus to right side once, but still the focus will be on resume button and this time you press resume button, it will happily resume:) I didn't find this troubling my user experience since I found the workaround but happy someone noticed and fixed😁.

It wasn't fixed by my PR - it was some other scenario apparently.

Scenario 2:

Just boot the app, navigate to the movie and hit resume - it starts over :worried: 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- **Platform**: Tizen
- **Device Model**: UE50AU7105
- **Build Variant Tested**: Normal

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added appropriate JSDoc comments