### PR TITLE
Fix audio track switching bug in Tizen AVPlay

### DIFF
--- a/src/player/core/JellyfinPlayer.js
+++ b/src/player/core/JellyfinPlayer.js
@@ -1737,9 +1737,9 @@ export class JellyfinPlayer extends EventEmitter {
         // DirectPlay: native backend audio switching (no restart needed)
         // =====================================================================
 
-        // Both Tizen (AVPlay) and HtmlVideoPlayer work with 0-based list
-        // indices of available audio tracks, NOT the raw Jellyfin stream ID.
-        // Convert here so both backends share the same simple interface.
+        // HTML5 and WebOS expect a 0-based backend track-list index. Tizen
+        // expects the raw Jellyfin stream ID so it can resolve the matching
+        // AVPlay-native track index through its startup/pending track mapper.
         const tracks = this._getBackendAudioTracks();
         const listIndex = this._getBackendAudioTrackListIndex(index);
 
@@ -1749,8 +1749,13 @@ export class JellyfinPlayer extends EventEmitter {
             return;
         }
 
-        log.debug('Converting StreamID', index, 'to list index', listIndex);
-        this._backend?.setAudioStreamIndex(listIndex);
+        if (this._backendType === 'tizen') {
+            log.debug('Passing StreamID', index, 'to Tizen native track mapper');
+            this._backend?.setAudioStreamIndex(index);
+        } else {
+            log.debug('Converting StreamID', index, 'to list index', listIndex);
+            this._backend?.setAudioStreamIndex(listIndex);
+        }
 
         this.emit(PlayerEvent.MEDIA_STREAMS_CHANGE, { audioStreamIndex: index });
     }

--- a/src/player/core/TizenAVPlayer.js
+++ b/src/player/core/TizenAVPlayer.js
@@ -1614,9 +1614,9 @@ export class TizenAVPlayer {
 
     /**
      * Set audio stream index
-     * @param {number} index - Audio stream index
+     * @param {number} streamIndex - Jellyfin audio stream index
      */
-    setAudioStreamIndex(index) {
+    setAudioStreamIndex(streamIndex) {
         if (!this._avplay) {
             log.error('No avplay instance');
             return;
@@ -1626,33 +1626,13 @@ export class TizenAVPlayer {
             return;
         }
 
+        // Reuse the startup selection path so live switches resolve the raw
+        // Jellyfin stream ID to the matching AVPlay-native track index.
+        this._currentAudioStreamIndex = streamIndex;
+        this._pendingAudioIndex = streamIndex;
+
         try {
-            const tracks = this._avplay.getTotalTrackInfo();
-            const audioTracks = tracks.filter((t) => t.type === 'AUDIO');
-
-            if (index >= 0 && index < audioTracks.length) {
-                const track = audioTracks[index];
-
-                // Per Samsung docs, setSelectTrack('AUDIO', ...) is only valid in
-                // PLAYING state for HLS/DASH. Defer via _pendingAudioIndex if not.
-                let avplayState = 'UNKNOWN';
-                try { avplayState = this._avplay.getState(); } catch (_) {}
-                if (avplayState !== 'PLAYING') {
-                    log.debug(`Audio track ${track.index} deferred — AVPlay state is '${avplayState}', not PLAYING`);
-                    const jellyfinStreamIndex = this._currentPlayOptions?.mediaSource?.MediaStreams
-                        ?.filter(s => s.Type === 'Audio')?.[index]?.Index;
-                    if (jellyfinStreamIndex !== undefined) {
-                        this._pendingAudioIndex = jellyfinStreamIndex;
-                    }
-                    this._currentAudioStreamIndex = index;
-                    return;
-                }
-
-                this._avplay.setSelectTrack('AUDIO', track.index);
-                this._currentAudioStreamIndex = index;
-            } else {
-                log.error('Invalid audio index:', index, 'max:', audioTracks.length - 1);
-            }
+            this._applyPendingTracks();
         } catch (e) {
             log.error('Set audio track failed:', e);
         }


### PR DESCRIPTION
## Description

This PR is for fixing the audio track switching behavior in Tizen avplay. I explained this one clearly in #316. So here I just mention the root cause and fix.

Tizen in-player switching used Jellyfin’s audio-list position against AVPlay’s differently ordered/filtered track list cause avplay audio index omits dts/truhd and so has different audio id's than jellyfin's stream index, which leads to selecting the wrong track.

Fix: We pass the raw Jellyfin stream ID and reuse Tizen’s startup mapper to resolve the correct AVPlay native.track.index. The initial startup playback path correctly maps the audio index of avplay and jellyfin, so I just reused the same inside the player too.
Fixes #316 

*AI Assisted code, manually reviewed and tested by me.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- **Platform**: [Tizen]
- **Device Model**: [UA55DU7000KLXL]
- **Build Variant Tested**: [Modern]

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [ ] I have added appropriate JSDoc comments

## Screenshots (if applicable)

If this PR changes the UI, please provide screenshots.
