### PR TITLE
fix(security): add central escapeHtml() and escape server-supplied strings at innerHTML sinks

### DIFF
--- a/src/components/EpgGrid.js
+++ b/src/components/EpgGrid.js
@@ -14,6 +14,7 @@ import { logger } from '../utils/Logger.js';
 import { i18n } from '../utils/i18n.js';
 import { eventBus } from '../core/EventBus.js';
 import { imageService } from '../utils/ImageService.js';
+import { escapeHtml } from '../utils/Utils.js';
 import CardRenderer from '../utils/CardRenderer.js';
 
 const log = logger.create('EpgGrid');
@@ -296,11 +297,11 @@ class EpgGrid {
             }
             <div class="epg-channel-logo-fallback grad-${fallbackData.gradNum}" 
                  style="${logoUrl ? 'display: none;' : 'display: flex;'}">
-                ${fallbackData.initials}
+                ${escapeHtml(fallbackData.initials)}
             </div>
             <div class="epg-channel-info">
-                <div class="epg-channel-name">${channel.Name}</div>
-                <div class="epg-channel-number">${channel.Number || ''}</div>
+                <div class="epg-channel-name">${escapeHtml(channel.Name)}</div>
+                <div class="epg-channel-number">${escapeHtml(channel.Number || '')}</div>
             </div>
         `;
         this.channelsTrack.appendChild(channelEl);
@@ -346,7 +347,7 @@ class EpgGrid {
                 <div class="epg-program-content">
                     <div class="epg-program-title">
                         <span class="epg-program-prefix hidden">‹</span>
-                        <span class="title-text">${program.Name}</span>
+                        <span class="title-text">${escapeHtml(program.Name)}</span>
                     </div>
                     <div class="epg-program-time">${this._formatProgramTime(program)}</div>
                 </div>

--- a/src/pages/DetailsPage.js
+++ b/src/pages/DetailsPage.js
@@ -38,6 +38,7 @@ import { storage } from '../utils/StorageService.js';
 import { formatDate } from '../utils/TimeUtils.js';
 import { themeSongPlayer } from '../utils/ThemeSongPlayer.js';
 import { detailsIcons, settingsIcons } from '../utils/Icons.js';
+import { escapeHtml } from '../utils/Utils.js';
 
 const log = logger.create('DetailsPage');
 
@@ -2039,12 +2040,12 @@ class DetailsPage extends Page {
         if (showTitle) {
             // If there is no logo displayed, style the title to span the full width of the container.
             const titleStyleAttr = !showLogo ? 'style="max-width: 100%;"' : '';
-            heroHtml += `<h1 class="details-title" ${titleStyleAttr}>${displayTitle}</h1>`;
+            heroHtml += `<h1 class="details-title" ${titleStyleAttr}>${escapeHtml(displayTitle)}</h1>`;
         }
 
         // Add the subtitle element underneath if present.
         if (displaySubtitle && displaySubtitle !== displayTitle) {
-            heroHtml += `<h2 class="details-original-title">${displaySubtitle}</h2>`;
+            heroHtml += `<h2 class="details-original-title">${escapeHtml(displaySubtitle)}</h2>`;
         }
 
         // Render episode season/number details for TV episodes.
@@ -2068,7 +2069,7 @@ class DetailsPage extends Page {
             const useSecondaryColor = storage.getItem('pref:secondaryTitleSecondaryColor') !== 'false';
             const colorClass = useSecondaryColor ? 'secondary-color' : '';
 
-            heroHtml += `<p class="details-episode-info clickable-subtitle ${colorClass}" id="episode-subtitle-link">${i18n.ensureBiDi(subtitleText)}</p>`;
+            heroHtml += `<p class="details-episode-info clickable-subtitle ${colorClass}" id="episode-subtitle-link">${escapeHtml(i18n.ensureBiDi(subtitleText))}</p>`;
         }
 
         // Finish appending standard metadata row and secondary date labels.

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -23,6 +23,7 @@ import { focusManager } from '../ui/FocusManager.js';
 import { storage } from '../utils/StorageService.js';
 import { logger } from '../utils/Logger.js';
 import { i18n } from '../utils/i18n.js';
+import { escapeHtml } from '../utils/Utils.js';
 import { eventBus } from '../core/EventBus.js';
 import { layoutManager } from '../ui/LayoutManager.js';
 import { imageService } from '../utils/ImageService.js';
@@ -1649,11 +1650,11 @@ class LoginPage extends Page {
                                     </div>
                                     <div class="server-info">
                                         <div class="name-row">
-                                            <span class="server-name">${server.name}</span>
+                                            <span class="server-name">${escapeHtml(server.name)}</span>
                                             <span class="server-badge" data-i18n="SavedBadge">${i18n.t('SavedBadge') || 'Saved'}</span>
-                                            ${server.version ? `<span class="server-version">v${server.version}</span>` : ''}
+                                            ${server.version ? `<span class="server-version">v${escapeHtml(server.version)}</span>` : ''}
                                         </div>
-                                        <span class="server-address">${server.address}</span>
+                                        <span class="server-address">${escapeHtml(server.address)}</span>
                                     </div>
                                 </li>
                             `;
@@ -1671,10 +1672,10 @@ class LoginPage extends Page {
                                     </div>
                                     <div class="server-info">
                                         <div class="name-row">
-                                            <span class="server-name">${server.name}</span>
-                                            ${server.version ? `<span class="server-version">v${server.version}</span>` : ''}
+                                            <span class="server-name">${escapeHtml(server.name)}</span>
+                                            ${server.version ? `<span class="server-version">v${escapeHtml(server.version)}</span>` : ''}
                                         </div>
-                                        <span class="server-address">${server.address}</span>
+                                        <span class="server-address">${escapeHtml(server.address)}</span>
                                     </div>
                                 </li>
                             `;
@@ -1691,10 +1692,10 @@ class LoginPage extends Page {
                     const index = this._discoveredServers.indexOf(server);
                     return `
                     <li class="server-item" data-server-index="${index}" tabindex="0">
-                        <span class="server-name">${server.name}</span>
+                        <span class="server-name">${escapeHtml(server.name)}</span>
                         <span class="server-badge" data-i18n="SavedBadge">Saved</span>
-                        <span class="server-address">${server.address}</span>
-                        ${server.version ? `<span class="server-version">v${server.version}</span>` : ''}
+                        <span class="server-address">${escapeHtml(server.address)}</span>
+                        ${server.version ? `<span class="server-version">v${escapeHtml(server.version)}</span>` : ''}
                     </li>
                 `;
                 })
@@ -1714,9 +1715,9 @@ class LoginPage extends Page {
                         const index = this._discoveredServers.indexOf(server);
                         return `
                         <li class="server-item" data-server-index="${index}" tabindex="0">
-                            <span class="server-name">${server.name}</span>
-                            <span class="server-address">${server.address}</span>
-                            ${server.version ? `<span class="server-version">v${server.version}</span>` : ''}
+                            <span class="server-name">${escapeHtml(server.name)}</span>
+                            <span class="server-address">${escapeHtml(server.address)}</span>
+                            ${server.version ? `<span class="server-version">v${escapeHtml(server.version)}</span>` : ''}
                         </li>
                     `;
                     })

--- a/src/pages/PlayerPage.js
+++ b/src/pages/PlayerPage.js
@@ -33,6 +33,7 @@ import { webosAdapter } from '../webos/WebOSAdapter.js';
 import { syncPlayManager } from '../core/syncplay/SyncPlayManager.js';
 import { globalClock } from '../ui/GlobalClock.js';
 import { osdIcons } from '../utils/Icons.js';
+import { escapeHtml } from '../utils/Utils.js';
 
 const log = logger.create('Player');
 
@@ -2286,7 +2287,10 @@ class PlayerPage extends Page {
 
         if (data && data.text && data.text.trim().length > 0) {
             // Render subtitle
-            overlay.innerHTML = `<span class="subtitle-line">${data.text}</span>`;
+            // Cue text is external content (SRT/VTT/ASS from the server or a
+            // sidecar file); SubtitleParser only strips ASS {...} tags, so
+            // HTML in cue text must be escaped before innerHTML.
+            overlay.innerHTML = `<span class="subtitle-line">${escapeHtml(data.text)}</span>`;
             overlay.classList.remove('hidden');
 
             /* -------------------------------------------------------------
@@ -2366,8 +2370,8 @@ class PlayerPage extends Page {
         if (!overlay) return;
 
         if (data && data.text && data.text.trim().length > 0) {
-            // Render the secondary subtitle text
-            overlay.innerHTML = `<span class="subtitle-line">${data.text}</span>`;
+            // Render the secondary subtitle text (escaped: external cue content)
+            overlay.innerHTML = `<span class="subtitle-line">${escapeHtml(data.text)}</span>`;
             overlay.classList.remove('hidden');
 
             /* -------------------------------------------------------------

--- a/src/pages/SettingsPage.js
+++ b/src/pages/SettingsPage.js
@@ -32,6 +32,7 @@ import { versionChecker } from '../utils/VersionChecker.js';
 import { settingsIcons, setIconStyle, getSupportedStyles } from '../utils/Icons.js';
 import { pinManager } from '../utils/PinManager.js';
 import { pinDialog } from '../ui/PinDialog.js';
+import { escapeHtml } from '../utils/Utils.js';
 
 const log = logger.create('SettingsPage');
 
@@ -7419,7 +7420,7 @@ class SettingsPage extends Page {
     _renderDropdown(id, options, currentValue, disabled = false) {
         // Find current label (using String conversion to match storage strings with number options)
         const currentOption = options.find((o) => String(o.value) === String(currentValue)) || options[0];
-        const currentLabel = currentOption ? i18n.ensureBiDi(currentOption.label) : i18n.t('Select');
+        const currentLabel = currentOption ? escapeHtml(i18n.ensureBiDi(currentOption.label)) : i18n.t('Select');
 
         // Render as a button that triggers the modal
         return `
@@ -7474,7 +7475,7 @@ class SettingsPage extends Page {
                         <button class="modal-option-btn ${String(opt.value) === String(currentValue) ? 'selected' : ''}" 
                                 data-value="${opt.value}"
                                 tabindex="0">
-                             <span style="margin-right: 12px;">${i18n.ensureBiDi(opt.label)}</span>
+                             <span style="margin-right: 12px;">${escapeHtml(i18n.ensureBiDi(opt.label))}</span>
                              ${badge}
                         </button>
                     `;
@@ -9519,8 +9520,8 @@ class SettingsPage extends Page {
                 quality: 90,
                 maxWidth: 300
             });
-            return `<img src="${imageUrl}" class="user-avatar" alt="${user.Name}" onerror="this.classList.add('hidden'); this.nextElementSibling.classList.remove('hidden')">
-                    <div class="user-avatar-placeholder hidden">${user.Name[0].toUpperCase()}</div>`;
+            return `<img src="${imageUrl}" class="user-avatar" alt="${escapeHtml(user.Name)}" onerror="this.classList.add('hidden'); this.nextElementSibling.classList.remove('hidden')">
+                    <div class="user-avatar-placeholder hidden">${escapeHtml(user.Name ? user.Name[0].toUpperCase() : '?')}</div>`;
         }
         return `<div class="user-avatar-placeholder">${user?.Name ? user.Name[0].toUpperCase() : '?'}</div>`;
     }

--- a/src/ui/HeroCarousel.js
+++ b/src/ui/HeroCarousel.js
@@ -18,6 +18,7 @@ import { imageService } from '../utils/ImageService.js';
 import { shouldShowScore } from '../utils/visibility.js';
 import { platformInfo } from '../utils/PlatformInfo.js';
 import { detailsIcons } from '../utils/Icons.js';
+import { escapeHtml } from '../utils/Utils.js';
 
 const log = logger.create('HeroCarousel');
 
@@ -134,7 +135,7 @@ class HeroCarousel {
             const logoSrc = isActive ? `src="${logoUrl}"` : `data-src="${logoUrl}"`;
             logoHtml = `<div class="hero-logo-container"><img ${logoSrc} alt="" class="hero-logo"></div>`;
         } else {
-            logoHtml = `<h1 class="hero-item-title">${i18n.ensureBiDi(item.Name)}</h1>`;
+            logoHtml = `<h1 class="hero-item-title">${escapeHtml(i18n.ensureBiDi(item.Name))}</h1>`;
         }
 
         // Meta Info Row
@@ -187,7 +188,7 @@ class HeroCarousel {
                     <div class="hero-meta-row">
                         ${metaHtml}
                     </div>
-                    <div class="hero-description" tabindex="-1">${i18n.ensureBiDi(item.Overview || '')}</div>
+                    <div class="hero-description" tabindex="-1">${escapeHtml(i18n.ensureBiDi(item.Overview || ''))}</div>
                 </div>
             </div>
         `;

--- a/src/utils/CardRenderer.js
+++ b/src/utils/CardRenderer.js
@@ -8,6 +8,7 @@
  */
 
 import { api } from '../api/index.js';
+import { escapeHtml } from './Utils.js';
 import { imageService } from './ImageService.js';
 import { i18n } from './i18n.js';
 import { storage } from './StorageService.js';
@@ -772,6 +773,12 @@ class CardRenderer {
             }
         }
 
+        // Title/subtitle derive from server-supplied fields (Name, SeriesName,
+        // ChannelName, CurrentProgram.Name, Role...) and land in innerHTML —
+        // escape once here, after all composition is done.
+        titleText = escapeHtml(titleText);
+        subtitleText = escapeHtml(subtitleText);
+
         // --- 3.5. List View Override ---
         // In list-view, we want the Title on the left and EVERY other piece of info
         // (Year, Role, Rating, Score) on the right. We move subtitle parts to metaHtml.
@@ -803,7 +810,7 @@ class CardRenderer {
         // Attach fallback data for LazyLoader to use on error
         const fbData = CardRenderer.getFallbackData(item.Name);
         const hideInitials = type === 'library';
-        const dataAttributes = `data-src="${imageUrl}" data-fb-name="${fbData.name}" data-fb-init="${fbData.initials}" data-fb-grad="${fbData.gradNum}" ${hideInitials ? 'data-fb-hide-initials="true"' : ''}`;
+        const dataAttributes = `data-src="${imageUrl}" data-fb-name="${escapeHtml(fbData.name)}" data-fb-init="${escapeHtml(fbData.initials)}" data-fb-grad="${fbData.gradNum}" ${hideInitials ? 'data-fb-hide-initials="true"' : ''}`;
 
         // ====================================================================
         // Expansion Eligibility Strategy
@@ -901,8 +908,8 @@ class CardRenderer {
                 ? `<canvas class="blurhash-canvas" data-blurhash="${blurHash}"></canvas>`
                 : '';
         const imagePart = imageUrl
-            ? `${imageInnerHtml}${thumbPart}${blurHashHtml}<img src="${placeholder}" ${dataAttributes} alt="${item.Name}" class="lazy ${canExpand ? 'poster-layer' : ''}" />`
-            : `${CardRenderer.getFallbackHtml(item, isLandscape, { hideInitials })}${isModern && type === 'library' ? `<div class="card-overlay-label">${i18n.ensureBiDi(item.Name)}</div>` : ''}`;
+            ? `${imageInnerHtml}${thumbPart}${blurHashHtml}<img src="${placeholder}" ${dataAttributes} alt="${escapeHtml(item.Name)}" class="lazy ${canExpand ? 'poster-layer' : ''}" />`
+            : `${CardRenderer.getFallbackHtml(item, isLandscape, { hideInitials })}${isModern && type === 'library' ? `<div class="card-overlay-label">${escapeHtml(i18n.ensureBiDi(item.Name))}</div>` : ''}`;
         const finalContextType = contextType || item.Type;
 
         const isHiddenLibraryLabel =
@@ -1057,8 +1064,8 @@ class CardRenderer {
 
         return `
             <div class="media-fallback grad-${data.gradNum}">
-                ${!hideInitials ? `<div class="media-fallback-initials">${data.initials}</div>` : ''}
-                ${!isModern ? `<div class="media-fallback-name">${data.name}</div>` : ''}
+                ${!hideInitials ? `<div class="media-fallback-initials">${escapeHtml(data.initials)}</div>` : ''}
+                ${!isModern ? `<div class="media-fallback-name">${escapeHtml(data.name)}</div>` : ''}
             </div>
         `;
     }

--- a/src/utils/LazyLoader.js
+++ b/src/utils/LazyLoader.js
@@ -11,6 +11,7 @@ import { logger } from './Logger.js';
 import { eventBus } from '../core/EventBus.js';
 import BlurHashDecoder from './BlurHashDecoder.js';
 import { storage } from './StorageService.js';
+import { escapeHtml } from './Utils.js';
 
 const log = logger.create('LazyLoader');
 
@@ -458,10 +459,12 @@ class LazyLoader {
 
             if (gradNum && initials && name && !parent.querySelector('.media-fallback')) {
                 const hideInitials = img.dataset.fbHideInitials === 'true';
+                // dataset.* decodes the escaped attribute values back to raw
+                // strings — escape again before insertAdjacentHTML.
                 const fallbackHtml = `
                     <div class="media-fallback grad-${gradNum}">
-                        ${!hideInitials ? `<div class="media-fallback-initials">${initials}</div>` : ''}
-                        ${!isModern ? `<div class="media-fallback-name">${name}</div>` : ''}
+                        ${!hideInitials ? `<div class="media-fallback-initials">${escapeHtml(initials)}</div>` : ''}
+                        ${!isModern ? `<div class="media-fallback-name">${escapeHtml(name)}</div>` : ''}
                     </div>
                 `;
                 parent.insertAdjacentHTML('afterbegin', fallbackHtml);

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -7,3 +7,26 @@
 export function randomInt(min, max) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
+
+/**
+ * Escapes a value for safe interpolation into HTML text content or
+ * double-quoted attribute values.
+ *
+ * The app renders many server-supplied strings (item names, EPG data,
+ * subtitle cues, discovery replies, backup labels) through innerHTML
+ * template literals. This is the single escaper for all such sinks.
+ * Note: i18n.ensureBiDi() is a BiDi layout helper only — it returns the
+ * input unchanged in LTR mode and must never be treated as an escaper.
+ *
+ * @param {*} value - Value to escape (coerced to string; null/undefined -> '')
+ * @returns {string} HTML-escaped string
+ */
+export function escapeHtml(value) {
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
## Description

Adds a central `escapeHtml()` escaper and applies it at the highest-severity `innerHTML` sinks where server-supplied strings are interpolated raw.

The codebase had **no HTML escaper** — `i18n.ensureBiDi()` was treated as one at 38 call sites, but it returns its input **unchanged** in LTR mode (`src/utils/i18n.js`). Any library item name, channel/program name (EPG/XMLTV), subtitle cue text, discovered/saved server name, or backup label is (or was) interpolated unescaped into `innerHTML` template literals, enabling stored XSS. The worst chains execute **before login** (LoginPage discovered/saved server list — `ServerName` from a spoofed LAN server or a previously connected malicious server) and **cross-user** (Settings → Backup labels).

**Verified end-to-end** (both builds from this branch vs `development@c808f53`, run against a mock malicious Jellyfin whose `ServerName` carries a `<img src=x onerror=...>` marker payload):
- PRE-PR build: after one login to the fake server and the server going offline, the login screen's saved-server list renders the stored name → **payload executes** (visible banner + HTTP callback to the mock server).
- POST-PR build (this PR): identical flow renders the payload as **literal text**; no execution, no callbacks, `window.__XSS_EXECUTED__` stays unset.

Changes:
- `src/utils/Utils.js`: new `escapeHtml()` (escapes `& < > " '`), documented as the single escaper
- `src/utils/CardRenderer.js`: escape card title/subtitle after composition, `alt` attribute, overlay label, fallback name/initials (both render paths), `data-fb-*` attributes
- `src/utils/LazyLoader.js`: re-escape `dataset.fbName/fbInit` before `insertAdjacentHTML` (`dataset` decodes the escaped attributes back to raw, so the image-error fallback path would otherwise still inject)
- `src/pages/LoginPage.js`: escape server name/address/version in all four server-list templates (pre-auth XSS)
- `src/pages/PlayerPage.js`: escape primary + secondary subtitle cue text (hostile SRT/VTT sidecars)
- `src/components/EpgGrid.js`: escape channel name/number and program name (external XMLTV data)
- `src/pages/DetailsPage.js`: escape hero title, original title, episode subtitle
- `src/ui/HeroCarousel.js`: escape hero item name and overview
- `src/pages/SettingsPage.js`: escape dropdown labels (covers cross-user backup-label XSS) and user avatar name; fixes a latent crash on empty `user.Name`

Known behavior change: intentional markup in `Overview` fields and subtitle styling tags now displays as source text. A tag-whitelist sanitizer is the right follow-up if rich text is wanted.

Fixes # (no existing issue — found during a full security review of `development`; can file one on request)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

- All four webpack variants compile cleanly with the change: `debug`, `normal`, `legacy`, `modern` (webpack 5.105.3, `npm ci` install).
- **XSS regression proof (before vs after)** — a mock Jellyfin server serving `ServerName: 'Attacker Media Server <img src=x onerror=...>'`:
  1. Login once to the mock server (passwordless test user), then take it offline
  2. Re-open the login screen: the saved-server list renders the stored name
  3. **Before (development@c808f53):** payload executes — red banner planted on the login screen and an HTTP callback received by the mock server
  4. **After (this branch):** payload renders as literal text; `window.__XSS_EXECUTED__` unset; zero callbacks
- Static sink comparison page exercising all four fixed template families (server name, card title, subtitle cue, EPG program name) with identical attacker strings: before-templates execute the marker, after-templates render it as text.
- Manual regression: titles containing `&`, quotes, and accented characters render correctly; episode `SxxExx − Name` composition intact; image-error fallback still shows name + initials.

- **Platform**: Web (Chrome/Chromium)
- **Device Model**: headless Chromium 1280×720
- **Build Variant Tested**: Debug (all variants compile-verified)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (JSDoc on `escapeHtml` documents the `ensureBiDi` misconception)
- [x] My changes generate no new warnings (clean webpack builds on all 4 variants)
- [x] I have added appropriate JSDoc comments

## Screenshots (if applicable)

Not a UI change; evidence screenshots of the before/after behavior are available on request (mock-server + test harness can be attached as a proof kit: `mock-server.js`, `sink-test.html`, before/after `debug` builds).
