### PR TITLE
fix(player): restore subtitle i/b/u styling lost by the XSS escaping fix

### DIFF
--- a/src/pages/PlayerPage.js
+++ b/src/pages/PlayerPage.js
@@ -33,7 +33,7 @@ import { webosAdapter } from '../webos/WebOSAdapter.js';
 import { syncPlayManager } from '../core/syncplay/SyncPlayManager.js';
 import { globalClock } from '../ui/GlobalClock.js';
 import { osdIcons } from '../utils/Icons.js';
-import { escapeHtml } from '../utils/Utils.js';
+import { sanitizeSubtitleText } from '../utils/Utils.js';
 
 const log = logger.create('Player');
 
@@ -2288,9 +2288,11 @@ class PlayerPage extends Page {
         if (data && data.text && data.text.trim().length > 0) {
             // Render subtitle
             // Cue text is external content (SRT/VTT/ASS from the server or a
-            // sidecar file); SubtitleParser only strips ASS {...} tags, so
-            // HTML in cue text must be escaped before innerHTML.
-            overlay.innerHTML = `<span class="subtitle-line">${escapeHtml(data.text)}</span>`;
+            // sidecar file); SubtitleParser only strips ASS {...} tags, so it
+            // must be sanitized before innerHTML. sanitizeSubtitleText escapes
+            // everything and re-allows only bare <i>/<b>/<u>/<em>/<strong>,
+            // preserving legitimate cue styling without an injection surface.
+            overlay.innerHTML = `<span class="subtitle-line">${sanitizeSubtitleText(data.text)}</span>`;
             overlay.classList.remove('hidden');
 
             /* -------------------------------------------------------------
@@ -2370,8 +2372,9 @@ class PlayerPage extends Page {
         if (!overlay) return;
 
         if (data && data.text && data.text.trim().length > 0) {
-            // Render the secondary subtitle text (escaped: external cue content)
-            overlay.innerHTML = `<span class="subtitle-line">${escapeHtml(data.text)}</span>`;
+            // Render the secondary subtitle text (sanitized: escapes all HTML,
+            // re-allows only bare i/b/u/em/strong styling tags)
+            overlay.innerHTML = `<span class="subtitle-line">${sanitizeSubtitleText(data.text)}</span>`;
             overlay.classList.remove('hidden');
 
             /* -------------------------------------------------------------

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -30,3 +30,24 @@ export function escapeHtml(value) {
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
 }
+
+/**
+ * Sanitizes subtitle cue text for the DOM subtitle overlay.
+ *
+ * SRT/WebVTT cues conventionally carry simple styling tags (<i>, <b>, <u>)
+ * which SubtitleParser._cleanText deliberately preserves, so fully escaping
+ * cue text (the XSS fix) also destroyed that legitimate formatting.
+ * This restores it safely: the input is escaped FIRST, and only the exact
+ * escaped spellings of whitelisted BARE tags are turned back into markup.
+ * No attribute-bearing tag can match the pattern, so event handlers, URLs,
+ * and any non-whitelisted tag (<img>, <script>, <font ...>) remain inert
+ * text.
+ *
+ * @param {*} text - Raw cue text from the subtitle parser
+ * @returns {string} HTML-safe string with basic i/b/u/em/strong styling intact
+ */
+export function sanitizeSubtitleText(text) {
+    if (text === null || text === undefined) return '';
+    return escapeHtml(text)
+        .replace(/&lt;(\/?)(i|b|u|em|strong)&gt;/gi, '<$1$2>');
+}


### PR DESCRIPTION
## Description

Follow-up to #334. Escaping cue text fixed the subtitle XSS, but it also broke
legitimate SRT/VTT styling — `<i>`/`<b>`/`<u>` cues started showing as literal
text. This adds `sanitizeSubtitleText()`: escape everything first, then
re-allow only bare styling tags, so the XSS fix is not weakened.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Verified on-device: styled cues render in italics again, plain cues and timing
unchanged. Unit checks confirm only bare whitelisted tags ever reach the DOM.

- **Platform**: webOS
- **Device Model**: UQ8000PSB
- **Build Variant Tested**: Normal

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added appropriate JSDoc comments
