### PR TITLE
fix(player): restore subtitle formatting lost to the XSS escaping fix

### DIFF
--- a/src/pages/PlayerPage.js
+++ b/src/pages/PlayerPage.js
@@ -33,7 +33,7 @@ import { webosAdapter } from '../webos/WebOSAdapter.js';
 import { syncPlayManager } from '../core/syncplay/SyncPlayManager.js';
 import { globalClock } from '../ui/GlobalClock.js';
 import { osdIcons } from '../utils/Icons.js';
-import { escapeHtml } from '../utils/Utils.js';
+import { sanitizeSubtitleText } from '../utils/Utils.js';
 
 const log = logger.create('Player');
 
@@ -2288,9 +2288,11 @@ class PlayerPage extends Page {
         if (data && data.text && data.text.trim().length > 0) {
             // Render subtitle
             // Cue text is external content (SRT/VTT/ASS from the server or a
-            // sidecar file); SubtitleParser only strips ASS {...} tags, so
-            // HTML in cue text must be escaped before innerHTML.
-            overlay.innerHTML = `<span class="subtitle-line">${escapeHtml(data.text)}</span>`;
+            // sidecar file); SubtitleParser only strips ASS {...} tags, so it
+            // must be sanitized before innerHTML. sanitizeSubtitleText escapes
+            // everything and re-allows only bare <i>/<b>/<u>/<em>/<strong>,
+            // preserving legitimate cue styling without an injection surface.
+            overlay.innerHTML = `<span class="subtitle-line">${sanitizeSubtitleText(data.text)}</span>`;
             overlay.classList.remove('hidden');
 
             /* -------------------------------------------------------------
@@ -2370,8 +2372,9 @@ class PlayerPage extends Page {
         if (!overlay) return;
 
         if (data && data.text && data.text.trim().length > 0) {
-            // Render the secondary subtitle text (escaped: external cue content)
-            overlay.innerHTML = `<span class="subtitle-line">${escapeHtml(data.text)}</span>`;
+            // Render the secondary subtitle text (sanitized: escapes all HTML,
+            // re-allows only bare i/b/u/em/strong styling tags)
+            overlay.innerHTML = `<span class="subtitle-line">${sanitizeSubtitleText(data.text)}</span>`;
             overlay.classList.remove('hidden');
 
             /* -------------------------------------------------------------

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -30,3 +30,24 @@ export function escapeHtml(value) {
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
 }
+
+/**
+ * Sanitizes subtitle cue text for the DOM subtitle overlay.
+ *
+ * SRT/WebVTT cues conventionally carry simple styling tags (<i>, <b>, <u>)
+ * which SubtitleParser._cleanText deliberately preserves, so fully escaping
+ * cue text (the XSS fix) also destroyed that legitimate formatting.
+ * This restores it safely: the input is escaped FIRST, and only the exact
+ * escaped spellings of whitelisted BARE tags are turned back into markup.
+ * No attribute-bearing tag can match the pattern, so event handlers, URLs,
+ * and any non-whitelisted tag (<img>, <script>, <font ...>) remain inert
+ * text.
+ *
+ * @param {*} text - Raw cue text from the subtitle parser
+ * @returns {string} HTML-safe string with basic i/b/u/em/strong styling intact
+ */
+export function sanitizeSubtitleText(text) {
+    if (text === null || text === undefined) return '';
+    return escapeHtml(text)
+        .replace(/&lt;(\/?)(i|b|u|em|strong)&gt;/gi, '<$1$2>');
+}

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -32,22 +32,57 @@ export function escapeHtml(value) {
 }
 
 /**
+ * Named/numeric HTML entities that legitimately appear in subtitle files.
+ * Decoded BEFORE escaping so pre-encoded files don't render as literal text
+ * ("AT&amp;T" -> "AT&T"). Single-pass replace: substituted text is never
+ * re-scanned, so "&amp;lt;" correctly becomes literal "&lt;" text.
+ * @private
+ */
+const SUBTITLE_ENTITIES = {
+    amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: '\u00A0'
+};
+
+/**
  * Sanitizes subtitle cue text for the DOM subtitle overlay.
  *
- * SRT/WebVTT cues conventionally carry simple styling tags (<i>, <b>, <u>)
- * which SubtitleParser._cleanText deliberately preserves, so fully escaping
- * cue text (the XSS fix) also destroyed that legitimate formatting.
- * This restores it safely: the input is escaped FIRST, and only the exact
- * escaped spellings of whitelisted BARE tags are turned back into markup.
- * No attribute-bearing tag can match the pattern, so event handlers, URLs,
- * and any non-whitelisted tag (<img>, <script>, <font ...>) remain inert
- * text.
+ * SRT/WebVTT cues legitimately carry simple markup: styling tags (<i>, <b>,
+ * <u>) preserved by SubtitleParser._cleanText, multi-line cues joined with
+ * <br> by the parser itself, and some releases (e.g. anime fansubs) use
+ * <font face/size/color>. Fully escaping cue text (the XSS fix) turned all
+ * of that into visible literal tags.
+ *
+ * This restores formatting safely, in three provably closed steps:
+ * 1. Decode pre-encoded HTML entities (bounded, single pass).
+ * 2. Escape EVERYTHING — the string is now inert.
+ * 3. Re-allow only the exact escaped spellings of whitelisted bare tags
+ *    (i/b/u/em/strong/br, incl. <br/> and <BR> forms) and font tags whose
+ *    face/size/color attributes are strictly double-quoted with values that
+ *    contain no entities (values therefore cannot break out of the quotes
+ *    or introduce new attributes — event handlers stay impossible).
+ * Anything else (<img>, <script>, attribute-carrying styling tags, unknown
+ * tags) remains escaped, inert text.
  *
  * @param {*} text - Raw cue text from the subtitle parser
- * @returns {string} HTML-safe string with basic i/b/u/em/strong styling intact
+ * @returns {string} HTML-safe string with cue styling and line breaks intact
  */
 export function sanitizeSubtitleText(text) {
     if (text === null || text === undefined) return '';
-    return escapeHtml(text)
-        .replace(/&lt;(\/?)(i|b|u|em|strong)&gt;/gi, '<$1$2>');
+    const decoded = String(text).replace(
+        /&(#x[0-9a-f]+|#[0-9]+|amp|lt|gt|quot|apos|nbsp);/gi,
+        (match, entity) => {
+            if (entity[0] === '#') {
+                const code = entity[1] === 'x' || entity[1] === 'X'
+                    ? parseInt(entity.slice(2), 16)
+                    : parseInt(entity.slice(1), 10);
+                return Number.isInteger(code) && code > 0 && code <= 0x10ffff
+                    ? String.fromCodePoint(code)
+                    : match;
+            }
+            return SUBTITLE_ENTITIES[entity.toLowerCase()] ?? match;
+        }
+    );
+    return escapeHtml(decoded)
+        .replace(/&lt;(\/?)(i|b|u|em|strong|br|font)\s*\/?&gt;/gi, '<$1$2>')
+        .replace(/&lt;font((?:\s+(?:face|size|color)=&quot;[^&]*&quot;)+\s*)&gt;/gi,
+            (match, attrs) => '<font' + attrs.replace(/&quot;/g, '"') + '>');
 }

--- a/src/utils/Utils.js
+++ b/src/utils/Utils.js
@@ -82,7 +82,10 @@ export function sanitizeSubtitleText(text) {
         }
     );
     return escapeHtml(decoded)
-        .replace(/&lt;(\/?)(i|b|u|em|strong|br|font)\s*\/?&gt;/gi, '<$1$2>')
-        .replace(/&lt;font((?:\s+(?:face|size|color)=&quot;[^&]*&quot;)+\s*)&gt;/gi,
+        // HTML tag/attribute whitespace is [ \t\n\r\f] only — JS \s also
+        // matches NBSP/\u2028/\ufeff etc., which browsers treat as attribute
+        // NAME characters, so allowing \s would emit renamed/junk attributes.
+        .replace(/&lt;(\/?)(i|b|u|em|strong|br|font)[ \t\n\r\f]*\/?&gt;/gi, '<$1$2>')
+        .replace(/&lt;font((?:[ \t\n\r\f]+(?:face|size|color)=&quot;[^&]*&quot;)+[ \t\n\r\f]*)&gt;/gi,
             (match, attrs) => '<font' + attrs.replace(/&quot;/g, '"') + '>');
 }


### PR DESCRIPTION
## Description

Follow-up to #334. Escaping cue text fixed the subtitle XSS but broke
legitimate formatting: styled cues (`<i>`/`<b>`/`<u>`) showed literal tags,
multi-line cues showed `<BR>` (the parsers join lines with `<br>`), and fansub
`<font face/size/color>` styling was lost.

`sanitizeSubtitleText()` restores all of it safely — decode entities, escape
everything, then re-allow only bare styling tags and strictly-quoted font
attributes, so nothing from the XSS fix is weakened.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Verified on-device that styled cues render correctly; unit and real-DOM
checks cover line breaks, entities, font attributes, and attack payloads
(only whitelisted tags ever reach the DOM, everything else stays inert text).

- **Platform**: webOS
- **Device Model**: UQ8000PSB
- **Build Variant Tested**: Normal

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added appropriate JSDoc comments
