### PR TITLE
Tweak music now playing

### DIFF
--- a/src/styles/player-page.css
+++ b/src/styles/player-page.css
@@ -113,7 +113,7 @@ body.lyrics-active .audio-player-center {
     position: relative;
     width: 500px;
     height: 500px;
-    border-radius: 24px;
+    border-radius: 18px;
     background-size: cover;
     background-position: center;
     box-shadow: 0 25px 60px rgba(0, 0, 0, 0.45);

--- a/src/styles/player-page.css
+++ b/src/styles/player-page.css
@@ -82,7 +82,7 @@
     height: 120%;
     background-size: cover;
     background-position: center;
-    filter: blur(40px) brightness(0.4);
+    filter: blur(130px) brightness(0.4);
     z-index: 1;
 }
 
@@ -96,9 +96,9 @@
     -webkit-justify-content: center;
     justify-content: center;
     z-index: 2;
-    /* Translate the cover photo up a bit vertically by default to leave space for info */
-    -webkit-transform: translateY(-30px);
-    transform: translateY(-30px);
+    /* Keep the album art and metadata vertically centered */
+    -webkit-transform: translateY(0px);
+    transform: translateY(0px);
     -webkit-transition: -webkit-transform 0.4s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.4s ease;
     transition: transform 0.4s cubic-bezier(0.25, 1, 0.5, 1), opacity 0.4s ease;
 }
@@ -111,12 +111,12 @@ body.lyrics-active .audio-player-center {
 
 .audio-album-art {
     position: relative;
-    width: 460px; /* Reduced slightly to ensure it doesn't crowd and fits beautifully on various screen sizes */
-    height: 460px; /* Reduced slightly from 500px */
+    width: 500px;
+    height: 500px;
     border-radius: 24px;
     background-size: cover;
     background-position: center;
-    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.65);
+    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.45);
     -webkit-transition: opacity 0.4s ease;
     transition: opacity 0.4s ease;
 }


### PR DESCRIPTION
## Description

Making music now playing screen a little more gorgeous.

Changes include album art size, background blur, shadow, and positioning.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

Tested manually on a Samsung Tizen TV.
Platform: Tizen
Device Model: UA65CU7700
Build Variant Tested: Normal
Built and installed modified .wgt package and verified the Now Playing screen during music playback. Album art size, background blur, shadow intensity, and vertical positioning were checked visually.
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] I have added appropriate JSDoc comments

## Screenshots
Before:
<img width="2837" height="1596" alt="1" src="https://github.com/user-attachments/assets/77ad13cd-29cd-4017-af98-247e2c50ee50" />

After:
<img width="1419" height="798" alt="Screenshot 2026-08-30 at 00 25 55" src="https://github.com/user-attachments/assets/a8a0be6f-3eca-46bb-b5d7-94ccd63ce8bf" />

<img width="2838" height="1596" alt="1" src="https://github.com/user-attachments/assets/d6ac358b-0460-45b3-a002-358b8ed88f88" />
Art+Metadata centered.