### PR TITLE
fix(i18n): locale file fails to load when the app boots into a hash route

### DIFF
--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -98,8 +98,12 @@ class I18nManager {
         const protocol = window.location.protocol;
 
         if (protocol === 'file:') {
-            // file:// packaged app — origin is null/useless, extract base from raw href
-            base = href.substring(0, href.lastIndexOf('/') + 1);
+            // file:// packaged app — origin is null/useless, extract base from raw href.
+            // Strip hash/search FIRST: hash-router routes (#/player/<id>/resume)
+            // contain slashes, which would corrupt the base path and 404 the
+            // locale fetch whenever the app boots into a deep link.
+            const pathOnly = href.split('#')[0].split('?')[0];
+            base = pathOnly.substring(0, pathOnly.lastIndexOf('/') + 1);
         } else {
             // http:// or https:// — use origin+pathname to avoid hash-router fragments
             const pageUrl = window.location.origin + window.location.pathname;


### PR DESCRIPTION
## Description

Regression from d20c4f59. On packaged (file://) builds, `_localeUrl` derives
the base with `lastIndexOf('/')` on the raw href — and hash-router routes
contain slashes. Booting straight into a route like `#/player/<id>/resume`
(a deep link) makes it fetch `.../index.html#/player/<id>/locales/en-us.json`,
which fails and leaves both dictionaries empty — every `t()` then renders the
raw key ("SearchPlaceholder", "EndsAtValue"…). A second user independently
hit this on the legacy variant in 1.8.0.

Strip the fragment and query string before extracting the directory,
mirroring what the http branch already does via origin+pathname.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring

## How Has This Been Tested?

On-device (webOS, packaged build, deep-linked boot): before, the i18n log
shows the corrupted URL and "Init failed, falling back to empty dict"; after,
the clean URL and "Successfully loaded 1544 keys". HTTP dev-server path
unchanged.

- **Platform**: webOS
- **Device Model**: UQ8000PSB
- **Build Variant Tested**: Normal

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] I have added appropriate JSDoc comments
